### PR TITLE
Fix mistakes in uwsgi config from introduced in previous refactoring

### DIFF
--- a/courtfinder/settings/base.py
+++ b/courtfinder/settings/base.py
@@ -42,7 +42,7 @@ path.append(join(DJANGO_ROOT, 'apps'))
 SECRET_KEY = '99z2o2nkqlks_#wmbz(&+-_q)c@r_j*3#zeyn)s6pv3iyo_s6i'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 TEMPLATE_DEBUG = DEBUG
 

--- a/uwsgi.conf
+++ b/uwsgi.conf
@@ -7,6 +7,6 @@ vacuum=True
 max-requests=5000
 processes=4
 daemonize=/srv/logs/daemon.log
-chdir=/srv/search/courtfinder
+chdir=/srv/search
 env=DJANGO_SETTINGS_MODULE=courtfinder.settings
 pp=/srv/search/courtfinder


### PR DESCRIPTION
Set the chdir option in uwsgi.conf to the correct root directory, and
changed the DEBUG setting to True in base.py as it was previously
set to such in local.py (which was removed).