### PR TITLE
Use standard ping.json from django-moj-irat

### DIFF
--- a/courtfinder/apps/healthcheck/urls.py
+++ b/courtfinder/apps/healthcheck/urls.py
@@ -1,7 +1,14 @@
 from django.conf.urls import patterns, url
 
+from moj_irat.views import PingJsonView
+
 urlpatterns = patterns('healthcheck.views',
-    url(r'^ping.json$', 'ping'),
+    url(r'^ping.json$', PingJsonView.as_view(
+        build_date_key='APP_BUILD_DATE',
+        commit_id_key='APP_GIT_COMMIT',
+        build_tag_key='APP_BUILD_TAG',
+        version_number_key='APP_VERSION',
+    ), name='ping_json'),
     url(r'^healthcheck.json$', 'healthcheck'),
     url(r'^pingdom-search-statistics$', 'pingdom_search_statistics'),
 )

--- a/courtfinder/apps/healthcheck/views.py
+++ b/courtfinder/apps/healthcheck/views.py
@@ -12,24 +12,6 @@ from dateutil import tz
 from search.models import SearchStatistic
 
 
-def ping(request):
-    """
-    IRaT ping.json: returns build information
-    """
-    response = {
-        'version_number': None,
-        'build_date': None,
-        'commit_id': None,
-        'build_tag': None,
-    }
-    try:
-        with open(os.path.join(settings.PROJECT_ROOT, 'BUILD_VERSION.json')) as f:
-            response.update(json.load(f))
-    except (IOError, Exception):
-        pass
-    return JsonResponse(response)
-
-
 def healthcheck(request):
     """
     IRaT healthcheck.json: returns status of dependency services

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,5 +8,5 @@ boto==2.29.1
 python-dateutil==2.2
 raven==5.1.1
 LogentriesLogger==0.2.1
-uWSGI==2.0.8
+uWSGI==2.0.11.2
 postcodeinfo>=0.0,<1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,4 @@ raven==5.1.1
 LogentriesLogger==0.2.1
 uWSGI==2.0.11.2
 postcodeinfo>=0.0,<1.0
+git+https://github.com/ministryofjustice/django-moj-irat.git


### PR DESCRIPTION
[django-moj-irat](https://github.com/ministryofjustice/django-moj-irat) offers a ready-made, well-tested `ping.json` implementation that behaves in the way we want (using environment variables to provide its values), so we should use that instead of maintaining our own.

This depends on ministryofjustice/django-moj-irat#4, which adds support for Python 2.7.

For this to behave as intended, we need `APP_BUILD_DATE`, `APP_GIT_COMMIT`, `APP_BUILD_TAG`, and `APP_VERSION` environment variables to be appropriately set.