### PR TITLE
Set environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /srv/search
 
 WORKDIR /srv/search/courtfinder
 ENV DJANGO_SETTINGS_MODULE courtfinder.settings.production
+ENV RAILS_ENV production
 
 ADD gulpfile.js /srv/additional_files/gulpfile.js
 WORKDIR /srv/additional_files

--- a/courtfinder/settings/production.py
+++ b/courtfinder/settings/production.py
@@ -8,15 +8,15 @@ STATIC_ROOT = '/srv/search/assets/'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'courtfinder_search',
-        'USER': 'courtfinder',
-        'PASSWORD': 'C1cwG3P7n2',
+        'NAME': os.getenv('DB_NAME','courtfinder_search'),
+        'USER': os.getenv('DB_USER', 'courtfinder'),
+        'PASSWORD': os.getenv('DB_PASSWORD','C1cwG3P7n2'),
         'HOST': os.getenv('DB_HOST', '127.0.0.1'),
-        'PORT': '5432',
+        'PORT': os.getenv('DB_PORT', '5432'),
     }
 }
 
 ALLOWED_HOSTS = '*'
 
-COURTFINDER_ADMIN_HEALTHCHECK_URL = 'https://courttribunalfinder.service.gov.uk/admin/healthcheck.json'
-COURTS_DATA_S3_URL = 'https://s3-eu-west-1.amazonaws.com/courtfinder-json-production/courts.json'
+COURTFINDER_ADMIN_HEALTHCHECK_URL = os.getenv('COURTFINDER_ADMIN_HEALTHCHECK_URL', 'https://courttribunalfinder.service.gov.uk/admin/healthcheck.json')
+COURTS_DATA_S3_URL = os.getenv('COURTS_DATA_S3_URL', 'https://s3-eu-west-1.amazonaws.com/courtfinder-json-production/courts.json')


### PR DESCRIPTION
Currently environment variables are hard coded, this change means that
we can pass them in.

* Use database DB_ environment variables if they exist
* Use COURTFINDER_ADMIN_HEALTHCHECK_URL from environment if exists
* Use COURTS_DATA_S3_URL from environment if exists
* Make sure RAILS_ENV=production in Dockerfile