### PR TITLE
Fix test utils call to populate-db

### DIFF
--- a/courtfinder/test_utils.py
+++ b/courtfinder/test_utils.py
@@ -4,4 +4,4 @@ from django.test import TestCase
 
 class TestCaseWithData(TestCase):
     def setUp(self):
-        call_command('populate-db', 'data/test_data', verbosity='0')
+        call_command('populate-db', 'data/test_data', verbosity='0', ingest='0')


### PR DESCRIPTION
populate-db now requires options to be passed such as --load-remote
or --ingest, this change updates the test calls to reflect this
change.