### PR TITLE
Make populate-db callable as a script or functions

### DIFF
--- a/courtfinder/apps/search/management/commands/populate-db.py
+++ b/courtfinder/apps/search/management/commands/populate-db.py
@@ -36,7 +36,12 @@ class Command(BaseCommand):
             action='store_true',
             dest='ingest',
             default=False,
-            help='Ingest the local court files')
+            help='Ingest the local court files'),
+        make_option('--sys-exit',
+            action='store_true',
+            dest='sys-exit',
+            default=False,
+            help='Make the script use sys exits')
     )
 
     def handle(self, *args, **options):
@@ -64,13 +69,21 @@ class Command(BaseCommand):
             # asked for the files to be ingested,then exit
             if not files_changed and not options['ingest']:
                 logger.error("handle: Loaded remote files are unchanged")
-                sys.exit(1)
+                if (options['sys-exit']):
+                    sys.exit(1)
+                else:
+                    return
             
         if options['ingest']:
             self.import_files(local_dir, courts_files)
+            if (options['sys-exit']):
+                    sys.exit(0)
+            else:
+                return
+        if (options['sys-exit']):
             sys.exit(0)
-
-        sys.exit(0)
+        else:
+            return
 
     def load_remote_files(self,
                           local_dir,

--- a/data/import-utilities/ingest-json.sh
+++ b/data/import-utilities/ingest-json.sh
@@ -13,11 +13,11 @@ psql ${PSQL_ARGS} -c "DROP DATABASE ${DB_NAME_TMP};"
 
 
 echo Populating temporary database...
-$PYTHON manage.py populate-db --load-remote
+$PYTHON manage.py populate-db --load-remote --sys-exit
 if [ $? -eq 0 ]; then
 	echo Creating temporary database...
 	psql ${PSQL_ARGS} -c "CREATE DATABASE ${DB_NAME_TMP} WITH TEMPLATE ${DB_NAME} OWNER ${DB_USERNAME};"
-	$PYTHON manage.py populate-db --ingest
+	$PYTHON manage.py populate-db --ingest --sys-exit
 	if [ $? -eq 0 ]; then 
 		echo Replacing ${DB_NAME} with newly populated database ${DB_NAME_TMP}...
 		psql ${PSQL_ARGS} -c "DROP DATABASE ${DB_NAME};"


### PR DESCRIPTION
For some invocations we require sys exits, but we also need the script
to conform to django command standards for testing. This change will
make the script usage accessible when passed the --script parameter.