### PR TITLE
Allow passing courts data directory to populate-db

### DIFF
--- a/courtfinder/apps/search/management/commands/populate-db.py
+++ b/courtfinder/apps/search/management/commands/populate-db.py
@@ -27,6 +27,12 @@ class Command(BaseCommand):
 
     # Add some custom options
     option_list = BaseCommand.option_list + (
+        make_option('--datadir',
+            action='store',
+            type='string',
+            dest='datadir',
+            default='data',
+            help='Set the data directory containing courts files'),
         make_option('--load-remote',
             action='store_true',
             dest='load-remote',
@@ -49,7 +55,7 @@ class Command(BaseCommand):
         Handle the loading of file data into the application
         """
         courts_files = ["courts.json"]
-        local_dir = "data"
+        local_dir = options['datadir']
         remote_dir = ""
         files_changed = False
         exit_code = 0

--- a/courtfinder/test_utils.py
+++ b/courtfinder/test_utils.py
@@ -4,4 +4,4 @@ from django.test import TestCase
 
 class TestCaseWithData(TestCase):
     def setUp(self):
-        call_command('populate-db', 'data/test_data', verbosity='0', ingest='0')
+        call_command('populate-db', datadir='data/test_data', verbosity='0', ingest='0')


### PR DESCRIPTION
This change allows us to specify a directory on the command line,
which is required when we pass in testing data.