### PR TITLE
Implement multiple database support for courts.json data ingestion

### DIFF
--- a/courtfinder/apps/search/ingest.py
+++ b/courtfinder/apps/search/ingest.py
@@ -6,30 +6,30 @@ from django.db import IntegrityError
 
 class Ingest(object):
     @classmethod
-    def courts(cls, courts):
-        Court.objects.all().delete()
-        CourtAttributeType.objects.all().delete()
-        CourtAttribute.objects.all().delete()
-        CourtPostcode.objects.all().delete()
-        AreaOfLaw.objects.all().delete()
-        Facility.objects.all().delete()
-        OpeningTime.objects.all().delete()
-        LocalAuthority.objects.all().delete()
-        CourtLocalAuthorityAreaOfLaw.objects.all().delete()
-        CourtFacility.objects.all().delete()
-        CourtOpeningTime.objects.all().delete()
-        CourtAreaOfLaw.objects.all().delete()
-        AddressType.objects.all().delete()
-        CourtAddress.objects.all().delete()
-        Contact.objects.all().delete()
-        CourtContact.objects.all().delete()
-        Email.objects.all().delete()
-        CourtEmail.objects.all().delete()
-        CourtType.objects.all().delete()
-        CourtCourtType.objects.all().delete()
-        DataStatus.objects.all().delete()
-        ParkingInfo.objects.all().delete()
-        Town.objects.all().delete()
+    def courts(cls, courts, database_name="default"):
+        Court.objects.using(database_name).all().delete()
+        CourtAttributeType.objects.using(database_name).all().delete()
+        CourtAttribute.objects.using(database_name).all().delete()
+        CourtPostcode.objects.using(database_name).all().delete()
+        AreaOfLaw.objects.using(database_name).all().delete()
+        Facility.objects.using(database_name).all().delete()
+        OpeningTime.objects.using(database_name).all().delete()
+        LocalAuthority.objects.using(database_name).all().delete()
+        CourtLocalAuthorityAreaOfLaw.objects.using(database_name).all().delete()
+        CourtFacility.objects.using(database_name).all().delete()
+        CourtOpeningTime.objects.using(database_name).all().delete()
+        CourtAreaOfLaw.objects.using(database_name).all().delete()
+        AddressType.objects.using(database_name).all().delete()
+        CourtAddress.objects.using(database_name).all().delete()
+        Contact.objects.using(database_name).all().delete()
+        CourtContact.objects.using(database_name).all().delete()
+        Email.objects.using(database_name).all().delete()
+        CourtEmail.objects.using(database_name).all().delete()
+        CourtType.objects.using(database_name).all().delete()
+        CourtCourtType.objects.using(database_name).all().delete()
+        DataStatus.objects.using(database_name).all().delete()
+        ParkingInfo.objects.using(database_name).all().delete()
+        Town.objects.using(database_name).all().delete()
 
         for court_obj in courts:
             court_created_at = court_obj.get('created_at', None)
@@ -40,7 +40,7 @@ class Ingest(object):
                 court_updated_at+'UTC') if court_updated_at else None
             parking = court_obj.get('parking', None)
             if parking:
-                parking_info = ParkingInfo.objects.create(onsite=parking.get('onsite', None),
+                parking_info = ParkingInfo.objects.db_manager(database_name).create(onsite=parking.get('onsite', None),
                                                           offsite=parking.get(
                                                               'offsite', None),
                                                           blue_badge=parking.get('blue_badge', None))
@@ -63,7 +63,7 @@ class Ingest(object):
                 updated_at=updated_at,
                 parking=parking_info if parking_info else None,
             )
-            court.save()
+            court.save(using=database_name)
 
             for aol_obj in court_obj['areas_of_law']:
                 aol_name = aol_obj['name']
@@ -71,8 +71,8 @@ class Ingest(object):
                 aol_las = aol_obj['local_authorities']
                 aol_spoe = aol_obj.get('single_point_of_entry',False)
                 try:
-                    aol, created = AreaOfLaw.objects.get_or_create(name=aol_name, slug=aol_slug)
-                    CourtAreaOfLaw.objects.create(court=court,
+                    aol, created = AreaOfLaw.objects.db_manager(database_name).get_or_create(name=aol_name, slug=aol_slug)
+                    CourtAreaOfLaw.objects.db_manager(database_name).create(court=court,
                                                 area_of_law=aol,
                                                 single_point_of_entry=aol_spoe)
                 except IntegrityError as e:
@@ -80,16 +80,16 @@ class Ingest(object):
                                 % (aol_name, aol_slug))
                 for local_authority in aol_las:
                     if isinstance(local_authority, dict):
-                        local_authority_object, created = LocalAuthority.objects.get_or_create(
+                        local_authority_object, created = LocalAuthority.objects.db_manager(database_name).get_or_create(
                             gss_code=local_authority.get('gss_code'),
                             name=local_authority['name'],
                         )
                     else:
-                        local_authority_object, created = LocalAuthority.objects.get_or_create(
+                        local_authority_object, created = LocalAuthority.objects.db_manager(database_name).get_or_create(
                             name=local_authority
                         )
 
-                    CourtLocalAuthorityAreaOfLaw.objects.create(
+                    CourtLocalAuthorityAreaOfLaw.objects.db_manager(database_name).create(
                         court=court,
                         area_of_law=aol,
                         local_authority=local_authority_object
@@ -100,39 +100,39 @@ class Ingest(object):
                 facility_description = facility_obj['description'] or facility_name
                 facility_image = facility_obj['image']
                 facility_image_description = facility_obj['image_description']
-                facility, created = Facility.objects.get_or_create(name=facility_name,
+                facility, created = Facility.objects.db_manager(database_name).get_or_create(name=facility_name,
                                                                    description=facility_description,
                                                                    image=facility_image,
                                                                    image_description=facility_image_description)
-                CourtFacility.objects.create(court=court, facility=facility)
+                CourtFacility.objects.db_manager(database_name).create(court=court, facility=facility)
 
             for opening_time in court_obj['opening_times']:
-                opening_time, created = OpeningTime.objects.get_or_create(
+                opening_time, created = OpeningTime.objects.db_manager(database_name).get_or_create(
                     description=opening_time)
-                CourtOpeningTime.objects.create(
+                CourtOpeningTime.objects.db_manager(database_name).create(
                     court=court, opening_time=opening_time)
 
             for email in court_obj['emails']:
-                email, created = Email.objects.get_or_create(
+                email, created = Email.objects.db_manager(database_name).get_or_create(
                     description=email['description'], address=email['address'])
-                CourtEmail.objects.create(court=court, email=email)
+                CourtEmail.objects.db_manager(database_name).create(court=court, email=email)
 
             for court_type_name in court_obj['court_types']:
-                ct, created = CourtType.objects.get_or_create(
+                ct, created = CourtType.objects.db_manager(database_name).get_or_create(
                     name=court_type_name)
 
-                CourtCourtType.objects.create(court=court, court_type=ct)
+                CourtCourtType.objects.db_manager(database_name).create(court=court, court_type=ct)
 
             for address in court_obj['addresses']:
-                address_type, created = AddressType.objects.get_or_create(
+                address_type, created = AddressType.objects.db_manager(database_name).get_or_create(
                     name=address['type'])
 
                 if address['town'] and not(address['town'].isspace()):
-                    town, created = Town.objects.get_or_create(
+                    town, created = Town.objects.db_manager(database_name).get_or_create(
                         name=address['town'], county=address['county'])
                     if not address['postcode']:
                         address['postcode'] = ""
-                    CourtAddress.objects.create(
+                    CourtAddress.objects.db_manager(database_name).create(
                         court=court,
                         address_type=address_type,
                         address=address['address'],
@@ -141,18 +141,18 @@ class Ingest(object):
                     )
 
             for contact_obj in court_obj['contacts']:
-                contact, created = Contact.objects.get_or_create(name=contact_obj['name'],
+                contact, created = Contact.objects.db_manager(database_name).get_or_create(name=contact_obj['name'],
                                                                  number=contact_obj[
                                                                      'number'],
                                                                  sort_order=contact_obj['sort'])
 
-                CourtContact.objects.create(
+                CourtContact.objects.db_manager(database_name).create(
                     court=court,
                     contact=contact,
                 )
 
             for postcode in court_obj['postcodes']:
-                CourtPostcode.objects.create(
+                CourtPostcode.objects.db_manager(database_name).create(
                     court=court,
                     postcode=postcode
                 )

--- a/courtfinder/settings/base.py
+++ b/courtfinder/settings/base.py
@@ -102,6 +102,14 @@ DATABASES = {
         'PASSWORD': 'C1cwG3P7n2',
         'HOST': os.getenv('DB_HOST', '127.0.0.1'),
         'PORT': '5432',
+    },
+    'temp': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'courtfinder_search_tmp',
+        'USER': 'courtfinder',
+        'PASSWORD': 'C1cwG3P7n2',
+        'HOST': os.getenv('DB_HOST', '127.0.0.1'),
+        'PORT': '5432',
     }
 }
 

--- a/courtfinder/settings/production.py
+++ b/courtfinder/settings/production.py
@@ -13,6 +13,14 @@ DATABASES = {
         'PASSWORD': os.getenv('DB_PASSWORD','C1cwG3P7n2'),
         'HOST': os.getenv('DB_HOST', '127.0.0.1'),
         'PORT': os.getenv('DB_PORT', '5432'),
+    },
+    '_tmp': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': '_tmp',
+        'USER': os.getenv('DB_USER', 'courtfinder'),
+        'PASSWORD': os.getenv('DB_PASSWORD','C1cwG3P7n2'),
+        'HOST': os.getenv('DB_HOST', '127.0.0.1'),
+        'PORT': os.getenv('DB_PORT', '5432'),
     }
 }
 

--- a/data/import-utilities/ingest-json.sh
+++ b/data/import-utilities/ingest-json.sh
@@ -2,7 +2,7 @@
 PYTHON=python
 
 # Name of the temp database to be used to store data during import
-DB_NAME_TMP="${DB_NAME}_tmp"
+DB_NAME_TMP="_tmp"
 
 # Setup postgres pasword and args
 export PGPASSWORD=${DB_PASSWORD}
@@ -12,11 +12,11 @@ echo Dropping any temporary database if it exists
 psql ${PSQL_ARGS} -c "DROP DATABASE IF EXISTS ${DB_NAME_TMP};"
 
 echo Populating temporary database...
-$PYTHON manage.py populate-db --load-remote --sys-exit
+$PYTHON manage.py populate-db --database ${DB_NAME_TMP} --load-remote --sys-exit
 if [ $? -eq 0 ]; then
 	echo Creating temporary database...
 	psql ${PSQL_ARGS} -c "CREATE DATABASE ${DB_NAME_TMP} WITH TEMPLATE ${DB_NAME} OWNER ${DB_USERNAME};"
-	$PYTHON manage.py populate-db --ingest --sys-exit
+	$PYTHON manage.py populate-db --database ${DB_NAME_TMP} --ingest --sys-exit
 	if [ $? -eq 0 ]; then 
 		echo Replacing ${DB_NAME} with newly populated database ${DB_NAME_TMP}...
 		psql ${PSQL_ARGS} -c "DROP DATABASE IF EXISTS ${DB_NAME};"


### PR DESCRIPTION
Implement multiple database support for courts.json data ingestion

Currently, calling ingest will always load the courts data into the default
database. When importing data, we want to import it into a temporary
database, and then swap this with the live one.
This change allows the --database parameter to be passed to the
populate-db script, and so the Ingest, which uses the identifier
to get/create/save objects to the matching database entry in the django settings file.

(Closes #122)