### PR TITLE
Add a survey request to top of search results

### DIFF
--- a/courtfinder/apps/search/templates/search/results.jinja
+++ b/courtfinder/apps/search/templates/search/results.jinja
@@ -21,11 +21,20 @@
 </div>
 <div id="search-results-page" class="content inner cf">
   <header class="page-header">
-    <h1>Search results</h1>
+    {# --- temporary survey request > #}
+    {% if aol == 'Children' or aol == 'Domestic violence' or aol == 'Divorce' %}
+      <p class="info-box" style="float:right; display:inline; width: 40%; padding: 20px 15px 20px 80px; margin-left: 50px; background: #EDEDED url('/assets/images/icon-information-2x.png') no-repeat scroll 15px 20px;">
+        Are you a separating parent?<br>
+        Your experience and thoughts can help us improve the services we offer.<br>
+        Take our <a href="https://www.surveymonkey.co.uk/r/HC72KHV">short survey</a>.
+      </p>
+    {% endif %}
+    {# --- < temporary survey request #}
+    <h1 style="float: left">Search results</h1>
   </header>
 
   {% if search_results %}
-  <div class="search-results">
+  <div class="search-results" style="clear: both">
     {% if query %}
     <p class="text-secondary">
       <span id="number-of-results">{{ search_results|length }}</span> result{{ search_results|length|pluralize }}

--- a/courtfinder/apps/search/tests/test_search.py
+++ b/courtfinder/apps/search/tests/test_search.py
@@ -156,21 +156,21 @@ class SearchTestCase(TestCaseWithData):
         with postcode_valid('lookup_partial_postcode'):
             response = c.get('/search/results?postcode=SE15&aol=all')
             self.assertEqual(response.status_code, 200)
-            self.assertIn('<div class="search-results">', response.content)
+            self.assertIn('<div class="search-results"', response.content)
 
     def test_partial_postcode_whitespace(self):
         c = Client()
         with postcode_valid('lookup_partial_postcode'):
             response = c.get('/search/results?postcode=SE15++&aol=all')
             self.assertEqual(response.status_code, 200)
-            self.assertIn('<div class="search-results">', response.content)
+            self.assertIn('<div class="search-results"', response.content)
 
     def test_postcode_whitespace(self):
         c = Client()
         with postcode_valid('lookup_postcode'):
             response = c.get('/search/results?postcode=++SE154UH++&aol=all')
             self.assertEqual(response.status_code, 200)
-            self.assertIn('<div class="search-results">', response.content)
+            self.assertIn('<div class="search-results"', response.content)
 
     def test_redirect_directive_action(self):
         rules = Mock(return_value={


### PR DESCRIPTION
Display request to do separating parents survey on the search results page for users who have chosen 'children', 'divorce', 'domestic abuse' as the area of law.