### PR TITLE
Fix condition used in check whether to show survey

### DIFF
--- a/courtfinder/apps/search/templates/search/results.jinja
+++ b/courtfinder/apps/search/templates/search/results.jinja
@@ -22,7 +22,7 @@
 <div id="search-results-page" class="content inner cf">
   <header class="page-header">
     {# --- temporary survey request > #}
-    {% if aol == 'Children' or aol == 'Domestic violence' or aol == 'Divorce' %}
+    {% if aol == 'Children' or aol == 'Domestic violence' or aol == 'Divorce' or aol == 'children' or aol == 'domestic violence' or aol == 'domestic-violence' or aol == 'divorce' %}
       <p class="info-box" style="float:right; display:inline; width: 40%; padding: 20px 15px 20px 80px; margin-left: 50px; background: #EDEDED url('/assets/images/icon-information-2x.png') no-repeat scroll 15px 20px;">
         Are you a separating parent?<br>
         Your experience and thoughts can help us improve the services we offer.<br>


### PR DESCRIPTION
Display request to do separating parents survey on the search results page for users who have chosen 'children', 'divorce', 'domestic abuse' as the area of law.

Compare lowercase area of law text in condition to ensure match occurs ignoring case.