### PR TITLE
Added rate limiting and a honeypot field to the feedback form

### DIFF
--- a/courtfinder/staticpages/forms.py
+++ b/courtfinder/staticpages/forms.py
@@ -1,0 +1,17 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+
+def require_no_value(value):
+    if value:
+        raise ValidationError("Field must be empty")
+
+
+class FeedbackForm(forms.Form):
+    feedback_text = forms.CharField(label='feedback_text', max_length=200)
+    feedback_referer = forms.CharField(label='feedback_referer', max_length=512)
+    feedback_email = forms.CharField(
+        label='feedback_email', max_length=2000, required=False)
+
+    # honeypot field - will be hidden in css
+    feedback_name = forms.CharField(label="Your name", required=False, validators=[require_no_value])

--- a/courtfinder/staticpages/templates/staticpages/feedback.jinja
+++ b/courtfinder/staticpages/templates/staticpages/feedback.jinja
@@ -21,6 +21,10 @@
         <div class="form-label">Your email address (optional) - if you'd like us to contact you for more feedback</div>
         <input name="feedback_email" type="email"/>
       </label>
+      <label for="feedback_name" class="hidden">
+        <div class="form-label">[Leave this field blank]</div>
+        <input name="feedback_name" type="text" />
+      </label>
       <div class="actions">
         <button id="continue" class="button" type="submit">Continue</button>
       </div>

--- a/courtfinder/staticpages/tests.py
+++ b/courtfinder/staticpages/tests.py
@@ -1,12 +1,11 @@
 import json
-import os
 from mock import Mock, patch
-from django.test import TestCase
+
 from django.test import TestCase, Client
 from django.conf import settings
+
 from search.ingest import Ingest
-
-
+from .forms import FeedbackForm
 
 
 class SearchTestCase(TestCase):
@@ -15,9 +14,6 @@ class SearchTestCase(TestCase):
         test_data_dir = settings.PROJECT_ROOT +  '/data/test_data/'
         courts_json_1 = open(test_data_dir + 'courts.json').read()
         Ingest.courts(json.loads(courts_json_1))
-
-    def tearDown(self):
-        pass
 
     def test_top_page_returns_correct_content(self):
         c = Client()
@@ -76,3 +72,29 @@ class SearchTestCase(TestCase):
         self.assertRedirects(r, '/courts/accrington-magistrates-court', 302)
         r = c.get('/?court_id=2038')
         self.assertEqual(r.status_code, 404)
+
+class FeedbackFormTestCase(TestCase):
+
+    def setUp(self):
+        self.post_data = {
+            "feedback_text": "ra ra ra",
+            "feedback_referer": "www.a.url.com",
+            "feedback_email": "",
+            "feedback_name": ""
+        }
+
+    def test_form_honeypot_field_invalid_if_not_empty(self):
+
+        self.post_data["feedback_name"] = "should be empty"
+
+        form = FeedbackForm(self.post_data)
+
+        self.assertFalse(form.is_valid())
+
+    def test_form_honeypot_field_valid_if_empty(self):
+
+        form = FeedbackForm(self.post_data)
+
+        self.assertTrue(form.is_valid())
+
+

--- a/courtfinder/staticpages/views.py
+++ b/courtfinder/staticpages/views.py
@@ -1,12 +1,25 @@
-import os
 import json
+import smtplib
+
 from django.shortcuts import render, redirect
-from django.core.urlresolvers import reverse
 from django.core.mail import send_mail
 from django.conf import settings
-from django import forms
 from django.http import HttpResponseRedirect, Http404
+
 from raven.contrib.django.raven_compat.models import client
+from brake.decorators import ratelimit
+
+from .forms import FeedbackForm
+
+
+EMAIL_MESSAGE = """
+New feedback has arrived for courtfinder (https://courttribunalfinder.service.gov.uk/).
+The user left feedback after seeing: {}
+User's browser: {}
+User's email: {}
+
+Message: {}
+"""
 
 
 def index(request):
@@ -15,52 +28,52 @@ def index(request):
     else:
         return redirect_old_id_to_slug(request.GET['court_id'])
 
+
 def api(request, extension=None):
     return render(request, 'staticpages/api.jinja')
+
 
 def feedback(request):
     return render(request, 'staticpages/feedback.jinja')
 
 
-class FeedbackForm(forms.Form):
-    feedback_text = forms.CharField(label='feedback_text', max_length=200)
-    feedback_referer = forms.CharField(label='feedback_referer', max_length=512)
-    feedback_email = forms.CharField(label='feedback_email', max_length=2000, required=False)
-
+@ratelimit(rate='3/h')
 def feedback_submit(request):
     form = FeedbackForm(request.POST)
-    if form.is_valid():
+
+    rate_limited = getattr(request, 'limited', False)
+
+    if form.is_valid() and not rate_limited:
         from_address = settings.FEEDBACK_EMAIL_SENDER
-        to_addresses = [address.strip() for address in settings.FEEDBACK_EMAIL_RECEIVER.split(',')]
+        to_addresses = [address.strip() for address in
+                        settings.FEEDBACK_EMAIL_RECEIVER.split(',')]
+
         if from_address and to_addresses:
             feedback_email = form.cleaned_data['feedback_email']
+
             if not feedback_email:
-                feedback_email = '(not provided)'
-            message = """
-New feedback has arrived for courtfinder (https://courttribunalfinder.service.gov.uk/).
-The user left feedback after seeing: %s
-User's browser: %s
-User's email: %s
+                feedback_email = "(no email supplied)"
 
-Message: %s
-""" % (form.cleaned_data['feedback_referer'],
-       request.META.get('HTTP_USER_AGENT','(unknown)'),
-       form.cleaned_data['feedback_email'],
-       form.cleaned_data['feedback_text'])
+            message = EMAIL_MESSAGE.format(
+                form.cleaned_data['feedback_referer'],
+                request.META.get('HTTP_USER_AGENT','(unknown)'),
+                feedback_email,
+                form.cleaned_data['feedback_text'])
 
-        try:
-            nb_emails_sent = send_mail('Feedback received for Court and Tribunal Finder',
-                                       message, from_address,
-                                       to_addresses, fail_silently=False)
-        except smtplib.SMTPException:
-            client.captureException()
-            # do nothing else in case of error. User doesn't need to see.
+            try:
+                send_mail('Feedback received for Court and Tribunal Finder',
+                          message, from_address,
+                          to_addresses, fail_silently=False)
 
+            except smtplib.SMTPException:
+                client.captureException()
 
     return redirect('staticpages:feedback_sent')
 
+
 def feedback_sent(request):
     return render(request, 'staticpages/feedback_sent.jinja')
+
 
 def redirect_old_id_to_slug(old_id):
     ids_file = settings.PROJECT_ROOT + '/data/old_id/ids.json'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,4 @@ LogentriesLogger==0.2.1
 uWSGI==2.0.11.2
 postcodeinfo>=0.0,<1.0
 git+https://github.com/ministryofjustice/django-moj-irat.git
+django-brake==1.5.2


### PR DESCRIPTION
To prevent feedback form spam I've added a rate limiter to the feedback post method which limits the requests to 3 per hour.  The rate limiter currently only limits on IP address, so we'll have to see if this is sufficient to prevent the spammer.

As an additional measure I've added a hidden honey pot field which needs to remain empty for the feedback form to be valid. 

If the rate limiter is triggered, or data is inputed into the honey pot field, the user will still see the feedback confirmation page, but no email will be sent.