### PR TITLE
Fix always ingesting courts data

### DIFF
--- a/courtfinder/search/management/commands/populate-db.py
+++ b/courtfinder/search/management/commands/populate-db.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         if exit_if_unchanged and not files_changed:
             self.logger.info("handle: Loaded remote files are unchanged...")
             if (options['sys-exit']):
-                sys.exit(0)
+                sys.exit(200)
             else:
                 return
 

--- a/data/import-utilities/ingest-json.sh
+++ b/data/import-utilities/ingest-json.sh
@@ -30,7 +30,11 @@ log "Result ${result}"
 
 log "Populating temporary database..."
 $PYTHON courtfinder/manage.py populate-db --database ${DB_NAME_TMP} --load-remote --sys-exit
-if [ $? -eq 0 ]; then
+if [ $? -eq 200 ]; then
+	# 200 exit code signifies no change
+    log "SUCCESS: No update required"
+    exit 0
+elif [ $? -eq 0 ]; then
 	log "Creating temporary database..."
 	result=$(psql ${PSQL_ARGS} -c "CREATE DATABASE ${DB_NAME_TMP} WITH TEMPLATE ${DB_NAME} OWNER ${DB_USERNAME};")
 	log "Result ${result}"


### PR DESCRIPTION
Since we exit 0 on no change in courts, the script interprets this as
needing to ingest courts. This change adds the exit code 200 to signify
no changes, and so the script can exit gracefully without importing any
data.