### PR TITLE
CF-109 Include closed courts in search results

### DIFF
--- a/courtfinder/assets-src/stylesheets/styles.scss
+++ b/courtfinder/assets-src/stylesheets/styles.scss
@@ -420,3 +420,12 @@ p.warning {
     text-indent: 2em;
   }
 }
+
+section.closedCourt
+{
+  background-color: #fef7f7;
+  clear: both;
+  border: 3px solid #df3034;
+  padding: 30px;
+  margin-bottom: 15px;
+}

--- a/courtfinder/search/court_search.py
+++ b/courtfinder/search/court_search.py
@@ -196,7 +196,7 @@ class CourtSearch:
         # put it all together and remove duplicates
         results = list(OrderedDict.fromkeys(chain(name_results, town_results, address_results, county_results)))
 
-        return [result for result in results if result.displayed]
+        return [result for result in results]
 
     def __court_number_search( self, query ):
         """

--- a/courtfinder/search/templates/search/results.jinja
+++ b/courtfinder/search/templates/search/results.jinja
@@ -31,7 +31,7 @@
   <div class="search-results">
     {% if query %}
     <p class="text-secondary">
-      <span id="number-of-results">{{ search_results|length }}</span> result{{ search_results|length|pluralize }}
+      <span id="number-of-results">{{ open_court_count }}</span> result{{ open_court_count|pluralize }}
     </p>
     {% else %}
     {%   if spoe %}
@@ -62,13 +62,9 @@
     <hr/>
     <ul id='court-results'>
       {% for court in search_results %}
+      {% if court.displayed %}
       <li>
         <h2>{{ court.name }}</h2>
-        {% if court.displayed == False %}
-        <section class="closedCourt">
-        <h3>This court or tribunal is no longer in service. Business has been transferred to other neighbouring courts.</h3>
-        </section>
-        {% endif %}
         <div class="court-addresses">
           <p>
             <span class="court-result-heading">Write to us:</span><br/>
@@ -123,6 +119,7 @@
         </p>
         <hr class="clear"/>
       </li>
+      {% endif %}
       {% endfor %}
     </ul>
   </div>

--- a/courtfinder/search/templates/search/results.jinja
+++ b/courtfinder/search/templates/search/results.jinja
@@ -64,6 +64,11 @@
       {% for court in search_results %}
       <li>
         <h2>{{ court.name }}</h2>
+        {% if court.displayed == False %}
+        <section class="closedCourt">
+        <h3>This court or tribunal is no longer in service. Business has been transferred to other neighbouring courts.</h3>
+        </section>
+        {% endif %}
         <div class="court-addresses">
           <p>
             <span class="court-result-heading">Write to us:</span><br/>
@@ -127,3 +132,4 @@
 {% block javascripts %}
     <script src='{% static "javascripts/application.js" %}'></script>
 {% endblock %}
+

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -177,10 +177,15 @@ class SearchTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('your browser sent a request',response.content)
 
-    def test_inactive_court(self):
+    def test_inactive_court_is_not_displaying_in_address_search_results(self):
+        c = Client()
+        response = c.get('/search/results?q=Some+old', follow=True)
+        self.assertIn('<span id="number-of-results">1</span>', response.content)
+
+    def test_address_search_single_inactive_court_result_redirects_to_closed_court(self):
         c = Client()
         response = c.get('/search/results?q=Some+old+closed+court', follow=True)
-        self.assertIn('closedCourt', response.content)
+        self.assertIn('alert', response.content)
 
     def test_substring_should_not_match(self):
         c = Client()

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -177,17 +177,10 @@ class SearchTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('your browser sent a request',response.content)
 
-
     def test_inactive_court(self):
-        court = Court.objects.create(
-            name="Example2 Court",
-            lat=0.0,
-            lon=0.0,
-            displayed=False,
-        )
         c = Client()
-        response = c.get('/search/results?q=Example2+Court', follow=True)
-        self.assertIn('validation-error', response.content)
+        response = c.get('/search/results?q=Some+old+closed+court', follow=True)
+        self.assertIn('closedCourt', response.content)
 
     def test_substring_should_not_match(self):
         c = Client()

--- a/courtfinder/search/views.py
+++ b/courtfinder/search/views.py
@@ -115,10 +115,12 @@ def results(request):
             results = CourtSearch(query=courtcode, courtcode_search=True).get_courts()
 
             if len(results) > 0:
+                open_court_count = sum(1 for result in results if result.displayed)
                 return render(request, 'search/results.jinja', {
                     'query': courtcode,
                     'courtcode_search': True,
-                    'search_results': __format_results(results)
+                    'search_results': __format_results(results),
+                    'open_court_count': open_court_count
                 })
             else:
                 return redirect(reverse('search:courtcode')+'?error=noresults&q='+courtcode)
@@ -127,13 +129,18 @@ def results(request):
         if query == '':
             return redirect(reverse('search:address')+'?error=noquery')
         else:
+            
             results = CourtSearch(query=query, courtcode_search=False).get_courts()
 
-            if len(results) > 0:
+            if len(results) == 1 and results[0].displayed == False:
+                return redirect(reverse('courts:court', kwargs={'slug': results[0].slug}) + '?q=' + query)
+            elif len(results) > 0:
+                open_court_count = sum(1 for result in results if result.displayed)
                 return render(request, 'search/results.jinja', {
                     'query': query,
                     'courtcode_search': False,
-                    'search_results': __format_results(results)
+                    'search_results': __format_results(results),
+                    'open_court_count': open_court_count
                 })
             else:
                 return redirect(reverse('search:address')+'?error=noresults&q='+query)

--- a/courtfinder/search/views.py
+++ b/courtfinder/search/views.py
@@ -245,7 +245,8 @@ def __format_results(results):
                   'slug': result.slug,
                   'types': sorted([court_type.court_type.name for court_type in result.courtcourttype_set.all()]),
                   'address': visible_address,
-                  'areas_of_law': areas_of_law }
+                  'areas_of_law': areas_of_law,
+                  'displayed' : result.displayed}
         dx_contacts = result.courtcontact_set.filter(contact__name='DX')
         if dx_contacts.count() > 0:
             court['dx_number'] = dx_contacts.first().contact.number

--- a/data/test_data/courts.json
+++ b/data/test_data/courts.json
@@ -333,5 +333,31 @@
         "contacts": [],
         "postcodes": [],
         "info": null        
+    },
+    {
+        "name": "Some old open court",
+        "slug": "old-open-court-still-in-use",
+        "lat": "2",
+        "lon": "2",
+        "admin_id": "34569433",
+        "display": true,
+        "court_number": "1235456",
+        "areas_of_law": [
+            {
+                "local_authorities": [], 
+                "name": "Money claims", 
+                "external_link_desc": null,
+                "external_link": null
+            }
+        ],
+        "emails": [ { "description": "Enquiries", "address": "spam@test.com" }],
+        "attributes": [],
+        "addresses": [],
+        "court_types": [],
+        "facilities": [],
+        "opening_times": [],
+        "contacts": [],
+        "postcodes": [],
+        "info": null        
     }
 ]


### PR DESCRIPTION
No migration in this change

Tests included/updated

This change redirects a user to a closed court if they specifically search for it in the "Court Name or Address" section.

Result count logic amended to work with the new change