### PR TITLE
CF-105 - Hide AoLs

### DIFF
--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -194,21 +194,23 @@
 
     </div>
 
-    <div id="areas_of_law">
-      {% if court.areas_of_law %}
-      <h2>Cases heard at this venue</h2>
-      <ul>
-        {% for aol in court.areas_of_law %}
-          {% if aol.external_link %}
-            <li><a href={{aol.display_url}} title="{{aol.external_link_desc}}">
-              <span class='screen_reader_hide'>{{aol.external_link_desc}}</span>{{ aol.name }}</a></li>
-          {% else %}
-            <li>{{ aol.name }}</li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-      {% endif %}
-    </div>
+    {% if court.hide_aols == False  %}
+      <div id="areas_of_law">
+        {% if court.areas_of_law %}
+        <h2>Cases heard at this venue</h2>
+        <ul>
+          {% for aol in court.areas_of_law %}
+            {% if aol.external_link %}
+              <li><a href={{aol.display_url}} title="{{aol.external_link_desc}}">
+                <span class='screen_reader_hide'>{{aol.external_link_desc}}</span>{{ aol.name }}</a></li>
+            {% else %}
+              <li>{{ aol.name }}</li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+    {% endif %}
     <div id="useful_links">
     <h2>Useful links:</h2>
       <a href="https://hmctsformfinder.justice.gov.uk/HMCTS/FormFinder.do">Find a form</a>

--- a/courtfinder/courts/tests.py
+++ b/courtfinder/courts/tests.py
@@ -1,3 +1,4 @@
+import pprint
 import requests
 import json
 import re
@@ -90,8 +91,14 @@ class SearchTestCase(TestCase):
         self.assertEquals(200, response.status_code)
         self.assertIn('This court or tribunal is no longer in service.',response.content)
 
-    def test_courts_cases_heard(self):
+    def test_courts_cases_heard_hide_aols(self):
         c = Client()
         response = c.get('/courts/accrington-magistrates-court')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Cases heard at this venue', response.content)
+
+    def test_courts_cases_heard_show_aols(self):
+        c = Client()
+        response = c.get('/courts/tameside-magistrates-court')
         self.assertEqual(response.status_code, 200)
         self.assertIn('Cases heard at this venue', response.content)

--- a/courtfinder/courts/views.py
+++ b/courtfinder/courts/views.py
@@ -73,7 +73,8 @@ def format_court(court):
                   'directions': court.directions if court.directions else None,
                   'alert': court.alert if court.alert and court.alert.strip() != '' else None,
                   'parking': court.parking or None,
-                  'info': court.info}
+                  'info': court.info,
+                  'hide_aols': court.hide_aols}
 
     dx_contact = court.contacts.filter(courtcontact__contact__name='DX')
     if dx_contact.count() > 0:

--- a/courtfinder/search/ingest.py
+++ b/courtfinder/search/ingest.py
@@ -62,7 +62,8 @@ class Ingest:
                 created_at=created_at,
                 updated_at=updated_at,
                 parking=parking_info if parking_info else None,
-                info=court_obj['info']
+                info=court_obj['info'],
+                hide_aols=court_obj['hide_aols']
             )
             court.save(using=database_name)
 

--- a/courtfinder/search/migrations/0010_court_hide_aols.py
+++ b/courtfinder/search/migrations/0010_court_hide_aols.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('search', '0009_court_info'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='court',
+            name='hide_aols',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        ),
+    ]

--- a/courtfinder/search/models.py
+++ b/courtfinder/search/models.py
@@ -26,6 +26,7 @@ class Court(models.Model):
     updated_at = models.DateTimeField(null=True, default=None)
     created_at = models.DateTimeField(null=True, default=None)
     info = models.TextField(null=True)
+    hide_aols = models.BooleanField(null=False, default=False)
 
     def postcodes_covered(self):
         return CourtPostcode.objects.filter(court=self)

--- a/courtfinder/search/templates/search/results.jinja
+++ b/courtfinder/search/templates/search/results.jinja
@@ -90,22 +90,25 @@
             {% endif %}
           </p>
         </div>
-        <div class="court-aol">
-          {% if court.areas_of_law %}
-          <p class="court-result-heading">Cases heard at this venue</p>
-          <ul>
-          {% for aol in court.areas_of_law %}
-            {% if aol.external_link %}
-              <li><a href="{{aol.display_url}}" title="{{aol.external_link_desc}}">
-              <span class='screen_reader_hide'>{{aol.external_link_desc}}</span>{{ aol.name }}</a></li>
-            {% else %}
-              <li>{{ aol.name }}</li>
+
+        {% if court.hide_aols == False %}
+          <div class="court-aol">
+            {% if court.areas_of_law %}
+            <p class="court-result-heading">Cases heard at this venue</p>
+            <ul>
+            {% for aol in court.areas_of_law %}
+              {% if aol.external_link %}
+                <li><a href="{{aol.display_url}}" title="{{aol.external_link_desc}}">
+                <span class='screen_reader_hide'>{{aol.external_link_desc}}</span>{{ aol.name }}</a></li>
+              {% else %}
+                <li>{{ aol.name }}</li>
+              {% endif %}
+            {% endfor %}
+            </ul>
             {% endif %}
-          {% endfor %}
-          </ul>
-          {% endif %}
-        </div>
-        
+          </div>
+        {% endif %}
+         
         <p class="clear">
           {% if query %}
             {% if courtcode_search == True %}

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -148,12 +148,6 @@ class SearchTestCase(TestCase):
         response = c.get('/search/results?aol=Crime&postcode=')
         self.assertRedirects(response, '/search/postcode?error=nopostcode&aol=Crime', 302)
 
-    def test_results_cases_heard(self):
-        c = Client()
-        response = c.get('/search/results?q=Accrington')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('Cases heard at this venue', response.content)
-
     def test_sample_postcode_all_aols(self):
         c = Client()
         response = c.get('/search/results?postcode=SE15+4UH&aol=All')
@@ -480,10 +474,21 @@ class SearchTestCase(TestCase):
         self.assertNotIn('http://sscs.venues.tribunals.gov.uk/venues/venues.htm', response.content)
         
     def test_gov_uk_links_exist(self):
-        
-        aol = AreaOfLaw.objects.get(name="Bankruptcy")
+        #Cannot use Accrington as it has AoLs hidden
         c = Client()
-        response = c.get('/search/results?aol=Bankruptcy&postcode=SW1H9AJ')
+        response = c.get('/search/results?aol=Bankruptcy&postcode=SA79RB')
         self.assertEqual(200, response.status_code)
         self.assertIn('https://www.gov.uk/bankruptcy', response.content)
         self.assertIn('More information on bankruptcy.', response.content)
+
+    def test_courts_cases_heard_hide_aols(self):
+        c = Client()
+        response = c.get('/search/results?q=Accrington+Magistrates')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Cases heard at this venue', response.content)
+
+    def test_courts_cases_heard_show_aols(self):
+        c = Client()
+        response = c.get('/search/results?q=Tameside+Magistrates')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Cases heard at this venue', response.content)

--- a/courtfinder/search/views.py
+++ b/courtfinder/search/views.py
@@ -253,7 +253,9 @@ def __format_results(results):
                   'types': sorted([court_type.court_type.name for court_type in result.courtcourttype_set.all()]),
                   'address': visible_address,
                   'areas_of_law': areas_of_law,
-                  'displayed' : result.displayed}
+                  'displayed' : result.displayed,
+                  'hide_aols': result.hide_aols}
+                  
         dx_contacts = result.courtcontact_set.filter(contact__name='DX')
         if dx_contacts.count() > 0:
             court['dx_number'] = dx_contacts.first().contact.number

--- a/data/test_data/courts.json
+++ b/data/test_data/courts.json
@@ -1,4 +1,5 @@
-[    {
+[    
+    {
         "addresses": [
             {
                 "town": "Accrington",
@@ -76,7 +77,6 @@
             "Magistrates Court"
         ],
         "name": "Accrington Magistrates' Court",
-        "display": true,
         "contacts": [
             {
                 "sort": 2,
@@ -158,7 +158,8 @@
         ],
         "image_file": "accrington_magistrates_court.jpg",
         "display": true,
-        "info": "<p>Test information on Accrington</>"
+        "info": "<p>Test information on Accrington</>",
+        "hide_aols": true
     },
     {
         "addresses": [
@@ -279,7 +280,8 @@
           "offsite": "Paid off site parking is available.",
           "blue_badge": "Blue badge parking is available on site."
         },
-        "info": "<p>Test information on Tameside</>"        
+        "info": "<p>Test information on Tameside</>",
+        "hide_aols": false       
     },
     {
         "name": "County Court Money Claims Centre (CCMCC)",
@@ -305,7 +307,8 @@
         "opening_times": [],
         "contacts": [],
         "postcodes": [],
-        "info": null        
+        "info": null,
+        "hide_aols": false        
     },
 
     {
@@ -332,7 +335,8 @@
         "opening_times": [],
         "contacts": [],
         "postcodes": [],
-        "info": null        
+        "info": null,
+        "hide_aols": false        
     },
     {
         "name": "Some old open court",
@@ -358,6 +362,40 @@
         "opening_times": [],
         "contacts": [],
         "postcodes": [],
-        "info": null        
+        "info": null,
+        "hide_aols": false        
+    },
+    {
+        "name": "Hide AoLs",
+        "slug": "Hide_AoLs",
+        "lat": "2",
+        "lon": "2",
+        "admin_id": "12121212",
+        "display": true,
+        "court_number": "1235456",
+        "areas_of_law": [
+            {
+                "local_authorities": [], 
+                "name": "Money claims", 
+                "external_link_desc": null,
+                "external_link": null
+            },
+            {
+                "local_authorities": [],
+                "name": "Bankruptcy",
+                "external_link_desc": "More information on bankruptcy.",
+                "external_link": "https://www.gov.uk/bankruptcy"
+            }
+        ],
+        "emails": [ { "description": "Enquiries", "address": "spam@test.com" }],
+        "attributes": [],
+        "addresses": [],
+        "court_types": [],
+        "facilities": [],
+        "opening_times": [],
+        "contacts": [],
+        "postcodes": ["SA79RB"],
+        "info": null,
+        "hide_aols": false        
     }
 ]


### PR DESCRIPTION
For some courts the AoLs need to be hidden so the user does not think they can turn up to the court.

Includes a migration.