### PR TITLE
Hotfix for empty brackets under court contacts

### DIFF
--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -138,7 +138,7 @@
             <div class="phone-label" property="contactPoint" typeof="ContactPoint">
               {% if contact.name != '' %}
                 <span class="label-pad" property="contactType">{{ contact.name }}:</span>
-                {% if contact.explanation != None %}
+                {% if contact.explanation != None and contact.explanation != '' %}
                   <br>({{ contact.explanation }})
                 {% endif %}
               {% endif %}


### PR DESCRIPTION
Fix to stop empty strings displaying in markup