### PR TITLE
CF-102 Allow leaflets to use raw html

### DIFF
--- a/courtfinder/courts/templates/courts/leaflets/_info.jinja
+++ b/courtfinder/courts/templates/courts/leaflets/_info.jinja
@@ -4,6 +4,6 @@
     <h2>Further help</h2>
     <p>Please see www.justice.gov.uk for further details regarding {{court.name}}</p>
     <h2>Further info</h2>
-    <p>{{court.info_leaflet}}</p>
+    <p>{{court.info_leaflet|safe}}</p>
   </div>
 {% endif %}

--- a/courtfinder/courts/templates/courts/leaflets/defence/_info.jinja
+++ b/courtfinder/courts/templates/courts/leaflets/defence/_info.jinja
@@ -2,6 +2,6 @@
 {% if court.info_leaflet %}
   <div id='info'>
     <h2>Further info</h2>
-    <p>{{court.prosecution_leaflet}}</p>
+    <p>{{court.defence_leaflet|safe}}</p>
   </div>
 {% endif %}

--- a/courtfinder/courts/templates/courts/leaflets/defence_leaflet.jinja
+++ b/courtfinder/courts/templates/courts/leaflets/defence_leaflet.jinja
@@ -23,10 +23,10 @@
         <div id='leaflet'>
             <div class="defence">
                 {% include "courts/leaflets/_leaflet_header.jinja" with title='You are a Defence Witness' %}
-                {% include "courts/leaflets/prosecution/_introduction.jinja" %}
+                {% include "courts/leaflets/defence/_introduction.jinja" %}
                 {% include "courts/leaflets/_court.jinja" %}
                 {% include "courts/leaflets/_contacts.jinja" %}
-                {% include "courts/leaflets/prosecution/_opening.jinja" %}
+                {% include "courts/leaflets/defence/_opening.jinja" %}
                 {% include "courts/leaflets/_facilities.jinja" %}
                 {% include "courts/leaflets/_roles.jinja" %}
                 {% include "courts/leaflets/_before_arrival.jinja" %}
@@ -37,7 +37,7 @@
                 {% include "courts/leaflets/_after_case.jinja" %}
                 {% include "courts/leaflets/_feedback.jinja" %}
                 {% include "courts/leaflets/_additional.jinja" %}
-                {% include "courts/leaflets/prosecution/_info.jinja" %}
+                {% include "courts/leaflets/defence/_info.jinja" %}
             </div>
         </div>
     </div>

--- a/courtfinder/courts/templates/courts/leaflets/juror/_info.jinja
+++ b/courtfinder/courts/templates/courts/leaflets/juror/_info.jinja
@@ -2,6 +2,6 @@
 {% if court.info_leaflet %}
   <div id='info'>
     <h2>Further info</h2>
-    <p>{{court.juror_leaflet}}</p>
+    <p>{{court.juror_leaflet|safe}}</p>
   </div>
 {% endif %}

--- a/courtfinder/courts/templates/courts/leaflets/prosecution/_info.jinja
+++ b/courtfinder/courts/templates/courts/leaflets/prosecution/_info.jinja
@@ -2,6 +2,6 @@
 {% if court.info_leaflet %}
   <div id='info'>
     <h2>Further info</h2>
-    <p>{{court.prosecution_leaflet}}</p>
+    <p>{{court.prosecution_leaflet|safe}}</p>
   </div>
 {% endif %}


### PR DESCRIPTION
The text fields used for additional information for each leaflet are now rich edit fields.

Path changed in defence leaflet to point at the correct folder.