### PR TITLE
Merged Dajngo migrations

### DIFF
--- a/courtfinder/search/migrations/0014_merge.py
+++ b/courtfinder/search/migrations/0014_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('search', '0013_contact_in_leaflet'),
+        ('search', '0012_emergencymessage'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
Django migrations were created in parallel git branches. This fix is the result of 'manage.py makemigrations --merge' which merges the django migrations together prevents migrate from asking for user input, necessary for successful jenkins deployments.