### PR TITLE
Put leaflets behind a feature flag

### DIFF
--- a/courtfinder/courtfinder/settings/base.py
+++ b/courtfinder/courtfinder/settings/base.py
@@ -252,6 +252,8 @@ COURT_IMAGE_BASE_URL = ''
 
 RATELIMIT_CACHE_BACKEND = 'courtfinder.brake_config.ELBBrake'
 
+FEATURE_LEAFLETS_ENABLED = False
+
 try:
     from .local import *
 except ImportError:

--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -239,7 +239,7 @@
       <br/>
       <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/complaints-procedure" title="Information on providing feedback about our services and making a complaint.">Make a complaint</a>
     </div>
-  {% comment %}
+  {% if feature_leaflet_enabled %}
    <div id="leaflets">
     <h2>Leaflets for printing:</h2>
       <a href={% url 'courts:leaflet' court.slug 'venue_information' %} title='Venue details for printing'>Venue details</a>
@@ -256,7 +256,7 @@
       {% endif %}
     </div>
   </div>
-  {% endcomment %}
+  {% endif %}
   {% endif %}
   <div id="last_update">
     Last updated: {{ court.updated_at }}

--- a/courtfinder/courts/tests.py
+++ b/courtfinder/courts/tests.py
@@ -151,32 +151,47 @@ class SearchTestCase(TestCase):
         self.assertIn('Maps and directions', response.content)
     
     def test_leaflet_links_for_magistrates_court(self):
-        c = Client()
-        response = c.get('/courts/leaflet-magistrates-court')
-        self.assertIn('Venue details for printing', response.content)
-        self.assertIn('Witness for prosecution information for printing', response.content)
-        self.assertIn('Witness for defence information for printing', response.content)
-        self.assertNotIn('Juror information for printing', response.content)
+        with self.settings(FEATURE_LEAFLETS_ENABLED=True):
+            c = Client()
+            response = c.get('/courts/leaflet-magistrates-court')
+            self.assertIn('Venue details for printing', response.content)
+            self.assertIn('Witness for prosecution information for printing', response.content)
+            self.assertIn('Witness for defence information for printing', response.content)
+            self.assertNotIn('Juror information for printing', response.content)
 
     def test_leaflet_links_for_crown_courts(self):
-        c = Client()
-        response = c.get('/courts/leaflet-crown-court')
-        self.assertIn('Venue details for printing', response.content)
-        self.assertIn('Witness for prosecution information for printing', response.content)
-        self.assertIn('Witness for defence information for printing', response.content)
-        self.assertIn('Juror information for printing', response.content)
+        with self.settings(FEATURE_LEAFLETS_ENABLED=True):
+            c = Client()
+            response = c.get('/courts/leaflet-crown-court')
+            self.assertIn('Venue details for printing', response.content)
+            self.assertIn('Witness for prosecution information for printing', response.content)
+            self.assertIn('Witness for defence information for printing', response.content)
+            self.assertIn('Juror information for printing', response.content)
     
     def test_leaflet_links_for_non_magistrate_or_non_crown_courts(self):
-        c = Client()
-        response = c.get('/courts/county-court-money-claims-centre-ccmcc')
-        self.assertIn('Venue details for printing', response.content)
-        self.assertNotIn('Witness for prosecution information for printing', response.content)
-        self.assertNotIn('Witness for defence information for printing', response.content)
-        self.assertNotIn('Juror information for printing', response.content)
+        with self.settings(FEATURE_LEAFLETS_ENABLED=True):
+            c = Client()
+            response = c.get('/courts/county-court-money-claims-centre-ccmcc')
+            self.assertIn('Venue details for printing', response.content)
+            self.assertNotIn('Witness for prosecution information for printing', response.content)
+            self.assertNotIn('Witness for defence information for printing', response.content)
+            self.assertNotIn('Juror information for printing', response.content)
     
     def test_court_image_url_is_based_on_settings(self):
         with self.settings(COURT_IMAGE_BASE_URL='http://example.com/images/'):
             c = Client()
             response = c.get('/courts/tameside-magistrates-court')
             self.assertIn("http://example.com/images/tameside_magistrates_court.jpg", response.content)
+
+    def test_leaflet_section_shown_when_enabled(self):
+        with self.settings(FEATURE_LEAFLETS_ENABLED=True):
+            c = Client()
+            response = c.get('/courts/leaflet-magistrates-court')
+            self.assertIn('Leaflets for printing', response.content)
+
+    def test_leaflet_section_not_shown_when_disabled(self):
+        with self.settings(FEATURE_LEAFLETS_ENABLED=False):
+            c = Client()
+            response = c.get('/courts/leaflet-magistrates-court')
+            self.assertNotIn('Leaflets for printing', response.content)
 

--- a/courtfinder/courts/views.py
+++ b/courtfinder/courts/views.py
@@ -117,6 +117,7 @@ def court(request, slug):
         'spoe': request.GET.get('spoe', None),
         'postcode': request.GET.get('postcode',''),
         'courtcode': request.GET.get('courtcode', False),
+        'feature_leaflet_enabled': settings.FEATURE_LEAFLETS_ENABLED,
     })
     
 def leaflet (request, slug, leaflet_type):


### PR DESCRIPTION
Before this change the leaflets markup had been commented out in the
template but the tests had not been commented out so some tests were
failing. This change introduces a feature flag that is switched off and
puts the markup behind that feature flag.

The tests now explicitly enable the feature flag and there are two new
tests verifying that the feature flag properly hides the leaflets
section.

When we come to enable leaflets we can now just enable the flag
in the environment we're interested in and then in production.