### PR TITLE
Fix vagrant setup

### DIFF
--- a/courtfinder/search/management/commands/populate-db.py
+++ b/courtfinder/search/management/commands/populate-db.py
@@ -162,7 +162,7 @@ class Command(BaseCommand):
         # determine where the json files are
         s3_bucket = os.environ.get('S3_BUCKET', None)
         if not s3_bucket:
-            self.logger.critical('handle: No S3_BUCKET environment variable found, {}'.format(bucket_name))
+            self.logger.critical('handle: No S3_BUCKET environment variable found')
             return False
         
         bucket_name = s3_bucket.split('.')[0]

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,49 +1,79 @@
 #!/bin/bash
+
 rm -f /home/vagrant/.ssh/known_hosts
 ssh-keyscan -t rsa,dsa -H github.com >> /home/vagrant/.ssh/known_hosts
 
-sudo add-apt-repository ppa:chris-lea/node.js
+echo "Installing debian dependencies"
+sudo apt-get clean
 sudo apt-get update
-sudo apt-get upgrade
-sudo apt-get -y install git postgresql postgresql-contrib postgresql-server-dev-9.3 build-essential python-dev libxml2-dev libxslt-dev python-setuptools nodejs ruby-sass libfontconfig redis-server libssl-dev libffi-dev python-pip
-sudo apt-get -y install python-psycopg2
-sudo apt-get -y install unoconv default-jre
+# Dependencies from Dockerfile
+sudo apt-get install --fix-missing -y \
+  postgis \
+  postgresql-9.3-postgis-2.1 \
+  python-pip \
+  python-dev \
+  wget \
+  npm \
+  ruby \
+  nodejs-legacy \
+  libpq-dev \
+  libnet-amazon-s3-tools-perl \
+  git \
+  build-essential \
+  libssl-dev \
+  libffi-dev
+# Application dependencies
+sudo apt-get install --fix-missing -y \
+  redis-server
+# Development tools
+sudo apt-get install --fix-missing -y \
+  htop
+
+# Add the en_GB locale
+locale -a | grep -q en_GB.utf8 || sudo locale-gen en_GB.UTF-8
+
+echo "Setting up virtualenv"
 #sudo easy_install pi#p
 sudo pip install virtualenvwrapper
 
 cd /home/vagrant/
 mkdir -p .envs
 
-sed -i '$a\
-\
-export WORKON_HOME=/home/vagrant/.envs\
-source /usr/local/bin/virtualenvwrapper.sh\
-workon courtfinder_search\
-echo -e "\\n\\n\\033[0;31mRun: ./manage.py runserver 0.0.0.0:8000\\033[0m\\n\\n"\
-' .bashrc
+grep -q "# courtfinder startup" .bashrc || cat << EOF >> .bashrc
+# courtfinder startup
+export WORKON_HOME=/home/vagrant/.envs
+source /usr/local/bin/virtualenvwrapper.sh
+workon courtfinder_search
+echo -e "\\n\\n\\033[0;31mRun: ./manage.py runserver 0.0.0.0:8000\\033[0m\\n\\n"
+EOF
 
-echo "Setting VE wrapper"
 WORKON_HOME=/home/vagrant/.envs
 source /usr/local/bin/virtualenvwrapper.sh
 
-echo "Making the VE"
 mkvirtualenv courtfinder_search
 setvirtualenvproject $VIRTUAL_ENV /courtfinder_search/
 workon courtfinder_search
 
-sudo mkdir /logs
+sudo mkdir -p /logs
 sudo chown vagrant /logs
 
+echo "Installing python dependencies"
+pip install setuptools==32
 pip install -r requirements.txt
 
-sudo -u postgres createuser --superuser vagrant 
-sudo -u postgres createdb courtfinder_search --owner=vagrant
+echo "Setting up postgres"
+sudo -u postgres bash -c "psql postgres -tAc 'SELECT 1 FROM pg_roles WHERE rolname='\''vagrant'\' | grep -q 1 || createuser --superuser vagrant"
+sudo -u postgres bash -c "psql postgres -tc 'SELECT 1 FROM pg_database WHERE datname = '\''courtfinder_search'\' | grep -q 1 || createdb courtfinder_search --owner=vagrant"
 
 cd /courtfinder_search/courtfinder/
 
 ./manage.py syncdb --noinput
 ./manage.py migrate --noinput
+./manage.py populate-db --datadir=../data/test_data --ingest
 
-#sudo npm install -g npm
-#npm install
-#sudo npm install -g gulp-cli
+echo "Installing frontend dependencies"
+sudo npm install gulp -g
+npm install
+sudo gem install sass
+
+gulp


### PR DESCRIPTION
## Fix the vagrant setup

The Vagrant bootstrapping was not working correctly. I have got it
working by basing it on the Dockerfile setup that is working correctly.

- Debian dependencies changed to match the Dockerfile. Dependencies that
  are not from the Dockerfile are pulled out separately to make the
  intent clear.
- Fixed the .bashrc was being updated to make it idempotent.
- Pin setuptools to version 32 to avoid a race condition (see:
  https://github.com/pypa/setuptools/issues/951#issuecomment-278933232)
- Fix postgres setup to make it idempotent.
- Fix frontend dependency install (this was broken because an incorrect
  version of node was being used, fixing the debian dependencies fixed
  this).

## Fix populate-db error message

Variable used before being defined. This code was rearranged to fail
early (good) but in doing so this error log was made invalid (bad).