### PR TITLE
Simplify and fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,46 +18,25 @@ RUN apt-get clean \
         libssl-dev \
         libffi-dev
 
-RUN pip install uWSGI==2.0.8
 
-COPY /docker/. /
-RUN mv /search /etc/sudoers.d/search; chmod 755 /run.sh; mkdir -p /srv/additional_files
-COPY ./package.json /srv/additional_files/package.json
-RUN bash /setup_npm.sh; 
 RUN useradd -m -d /srv/search search
+WORKDIR /srv/search
+COPY . .
+RUN mv ./docker/search /etc/sudoers.d/search
+
+RUN bash ./docker/setup_npm.sh
+RUN gulp
 
 RUN pip install pip --upgrade
-COPY ./requirements/base.txt /requirements.txt
-RUN pip install -r /requirements.txt
+RUN pip install -r requirements/production.txt
 
-RUN sudo -u search mkdir -p /srv/search
-
-COPY . /srv/search
-
-# RUN wget https://courttribunalfinder.service.gov.uk/courts.json -O /srv/search/data/courts.json
-
-WORKDIR /srv/search
-# RUN cp -R /srv/node_files/node_modules /srv/search/
-
-WORKDIR /srv/search/courtfinder
 ENV DJANGO_SETTINGS_MODULE courtfinder.settings.production
-ENV RAILS_ENV production
 
-ADD gulpfile.js /srv/additional_files/gulpfile.js
-WORKDIR /srv/additional_files
-RUN mkdir -p /srv/additional_files/courtfinder/assets-src && cp -R /srv/search/courtfinder/assets-src/* /srv/additional_files/courtfinder/assets-src
-RUN gulp
-RUN cp -R /srv/additional_files/* /srv/search
-
-WORKDIR /srv/search
 RUN python courtfinder/manage.py collectstatic --noinput
 
 RUN mkdir -p /srv/logs; chown -R search:search /srv/logs
 RUN chown -R search: /srv/search
 
-COPY ./docker/run.sh /run.sh
-RUN chmod +x /run.sh
-
 USER search
 
-CMD ["/bin/bash", "-l", "/run.sh"]
+CMD ["/bin/bash", "-l", "./run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-
-uwsgi --ini /srv/search/uwsgi.conf

--- a/docker/setup_npm.sh
+++ b/docker/setup_npm.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -e
-cd /srv/additional_files
 npm install
 npm install gulp -g
 npm install gulp --save-dev
 gem install sass
-cd /


### PR DESCRIPTION
## Backstory
We noticed that migrations are not being run when an app is deployed. Investigating pointed us towards commit 8496ce1 which uses a `run.sh` that doesn't respect the `DOCKER_STATE` environment variable.

I haven't been able to tie this back to a pull request. It looks like there was a large history change at some point in the past that this was involved in.

Further investigation revealed that the Dockerfile seems to be more complicated than is necessary.

## Solution
This change strips down and fixes the Dockerfile in a number of ways:
- Remove pip install uWSGI as the dependency is already in
  requirements.txt
- Simplify how the code is copied into place.
- Use the main `run.sh` which includes the `DOCKER_STATE` commands.
- Generate assets in place rather than doing so in a site directory
  (`/srv/additional_files`)

And outside of the Docker file:
- Remove cds from `setup_npm.sh` as the assets are no longer built on
  the side.
- Remove `docker/run.sh` as it confuses the situation.