### PR TITLE
Remove test dependency on mapit

### DIFF
--- a/courtfinder/search/court_search.py
+++ b/courtfinder/search/court_search.py
@@ -268,7 +268,7 @@ class Postcode():
         elif r.status_code in [400, 404]:
             loggers['mapit'].error("%d - %s - %s" % (r.status_code, postcode, r.text))
             raise CourtSearchInvalidPostcode('MapIt doesn\'t know this postcode: ' + mapit_url)
-        elif r.status_code == 403:
+        elif r.status_code in [403, 429]:
             loggers['mapit'].error("%d - %s - %s" % (r.status_code, postcode, r.text))
             raise CourtSearchError('MapIt rate limit exceeded: ' + str(r.status_code))
         else:


### PR DESCRIPTION
MapIt have recently introduced harsher rate limits on their API. This highlighted the fact that we're calling the MapIt API quite a lot in our tests. This change mocks out calls to MapIt so that we don't get hit by the rate limit and get much faster test runs.