### PR TITLE
Simplify basic postcode search

### DIFF
--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -229,30 +229,6 @@ class SearchTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('<p id="scotland">', response.content)
 
-#    def test_partial_postcode(self):
-#        c = Client()
-#        response = c.get('/search/results?postcode=SE15&aol=All')
-#        self.assertEqual(response.status_code, 200)
-#        self.assertIn('<div class="search-results">', response.content)
-
-#    def test_partial_postcode_whitespace(self):
-#        c = Client()
-#        response = c.get('/search/results?postcode=SE15++&aol=All')
-#        self.assertEqual(response.status_code, 200)
-#        self.assertIn('<div class="search-results">', response.content)
-
-#    def test_postcode_whitespace(self):
-#        c = Client()
-#        response = c.get('/search/results?postcode=++SE154UH++&aol=All')
-#        self.assertEqual(response.status_code, 200)
-#        self.assertIn('<div class="search-results">', response.content)
-
-#    def test_unknown_directive_action(self):
-#        with patch('search.rules.Rules.for_postcode', Mock(return_value={'action':'blah2389'})):
-#            c = Client()
-#            response = c.get('/search/results?postcode=SE15')
-#            self.assertRedirects(response, '/search/', 302)
-
     def test_redirect_directive_action(self):
         self.mock_mapit.side_effect = CourtSearchInvalidPostcode("MapIt doesn't know this postcode")
 

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -11,7 +11,8 @@ from search.ingest import Ingest
 
 class SearchTestCase(TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         test_data_dir = settings.PROJECT_ROOT +  '/data/test_data/'
         courts_json_1 = open(test_data_dir + 'courts.json').read()
         imports = json.loads(courts_json_1)
@@ -19,6 +20,7 @@ class SearchTestCase(TestCase):
         Ingest.emergency_message(imports['emergency_message'])
         DataStatus.objects.create(data_hash='415d49233b8592cf5195b33f0eddbdc86cebc72f2d575d392e941a53c085281a')
 
+    def setUp(self):
         self.mapit_patcher = patch('search.court_search.Postcode.mapit')
         self.mock_mapit = self.mapit_patcher.start()
         self.mock_mapit.return_value = {

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -377,6 +377,16 @@ class SearchTestCase(TestCase):
         response = c.get('/search/results?aol=Money%20claims&spoe=nearest&postcode=CF373AF')
         self.assertIn('Some old open court', response.content)
 
+    def test_money_claims_nearest_court_option_enter_postcode_prefix_match(self):
+        c = Client()
+        response = c.get('/search/results?aol=Money%20claims&spoe=nearest&postcode=CF373AF')
+        self.assertIn('No addresses', response.content)
+
+    def test_money_claims_nearest_court_option_enter_postcode_only_money_claims(self):
+        c = Client()
+        response = c.get('/search/results?aol=Money%20claims&spoe=nearest&postcode=CF373AF')
+        self.assertNotIn('Leaflet Magistrates Court', response.content)
+
     def test_money_claims_existing_online(self):
         c = Client()
         response = c.get('/search/postcode?aol=Money claims&spoe=continue')

--- a/data/test_data/courts.json
+++ b/data/test_data/courts.json
@@ -516,7 +516,9 @@
             "facilities": [],
             "opening_times": [],
             "contacts": [],
-            "postcodes": [],
+            "postcodes": [
+                "CF37"
+            ],
             "info": null,
             "hide_aols": false,
             "info_leaflet": null,
@@ -747,7 +749,9 @@
             "facilities": [],
             "opening_times": [],
             "contacts": [],
-            "postcodes": [],
+            "postcodes": [
+                "CF37"
+            ],
             "info": null,
             "hide_aols": false,
             "info_leaflet": null,


### PR DESCRIPTION
## Add tests around __postcode_search 
This adds two tests around the `CourtSearch.__postcode_search` method as a safety net for changing the implementation.

- One test to verify postcode prefix searches are working as expected.
- One test to verify that filtering by area of law is working as expected.

## Simplify postcode search
The intention of this change is to simplify and generally improve the postcode search.

The previous solution uses a rather complex raw query and an even more complex deduping approach (apparently for some marginal performance improvements). Given the effort placed on performance here I have assumed that there can be quite a lot of courts returned. I've tried to address that in a few of ways.

1. Replace the raw SQL with a Django ORM based query
This means that we can more easily join through the courts table to get the areas of law. This reduces the number of queries from N+2 to 1. This is likely to be the biggest gain. Unfortunately it still needs the raw where clause (see: http://stackoverflow.com/a/11906048/15720)

2. Move the area of law check into the query
We are querying through those join points anyway so we may as well do it all in the database.

3. Move the deduping into the query
The database is already handling this data and it is more obvious what's happening.

4. Remove the sorting
The only place that this method is used subsequently sorts the results by proximity so there's no need to sort.

## 	Remove commented out tests
These are already captured in version control.

## 	Move db setup to `setUpClass`
These tests are non-mutating so we don't need to set the database up again at the start of every test. This change takes the test run down from around 19s to around 5s.