### PR TITLE
Add Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+dist: trusty
+python:
+  - "2.7"
+services:
+  - postrgresql
+before_install:
+  - sudo ./apt/base.sh
+  - sudo ./apt/testing.sh
+install:
+  - "pip install setuptools==32"
+  - "pip install -r requirements.txt"
+  - "pip install -r requirements/testing.txt"
+  - "npm config set registry http://registry.npmjs.org/"
+  - "sudo $(which npm) install gulp -g"
+  - "npm install"
+  - "sudo gem install sass"
+before_script:
+  - "psql -c 'CREATE DATABASE courtfinder_search;' -U postgres"
+  - "python courtfinder/manage.py syncdb --noinput"
+  - "python courtfinder/manage.py populate-db --datadir=data/test_data --ingest"
+  - "gulp"
+script:
+  - "cd courtfinder && python manage.py test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,13 @@
 FROM ubuntu:14.04
 
-RUN apt-get clean \
-    && apt-get update \
-    && apt-get install --fix-missing -y \
-        postgis \
-        postgresql-9.3-postgis-2.1 \
-        python-pip \
-        python-dev \
-        wget \
-        npm \
-        ruby \
-        nodejs-legacy \
-        libpq-dev \
-        libnet-amazon-s3-tools-perl \
-        git \
-        build-essential \
-        libssl-dev \
-        libffi-dev
-
-
 RUN useradd -m -d /srv/search search
 WORKDIR /srv/search
 COPY . .
+
+RUN apt-get clean \
+    && apt-get update \
+    && ./apt/production.sh
+
 RUN mv ./docker/search /etc/sudoers.d/search
 
 RUN bash ./docker/setup_npm.sh

--- a/apt/base.sh
+++ b/apt/base.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+apt-get install --fix-missing -y \
+        postgis \
+        postgresql-9.3-postgis-2.1 \
+        python-pip \
+        python-dev \
+        wget \
+        ruby \
+        libpq-dev \
+        libnet-amazon-s3-tools-perl \
+        git \
+        build-essential \
+        libssl-dev \
+        libffi-dev

--- a/apt/development.sh
+++ b/apt/development.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+apt-get install --fix-missing -y \
+  redis-server \
+  htop

--- a/apt/production.sh
+++ b/apt/production.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+$(dirname $0)/base.sh
+
+apt-get install --fix-missing -y \
+        npm \
+        nodejs

--- a/apt/testing.sh
+++ b/apt/testing.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+apt-get install --fix-missing -y \
+  python-libxml2 \
+  python-libxslt1

--- a/docker/setup_npm.sh
+++ b/docker/setup_npm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
+ln -s /usr/bin/nodejs /usr/bin/node
 npm install
 npm install gulp -g
-npm install gulp --save-dev
 gem install sass

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -6,35 +6,13 @@ ssh-keyscan -t rsa,dsa -H github.com >> /home/vagrant/.ssh/known_hosts
 echo "Installing debian dependencies"
 sudo apt-get clean
 sudo apt-get update
-# Dependencies from Dockerfile
-sudo apt-get install --fix-missing -y \
-  postgis \
-  postgresql-9.3-postgis-2.1 \
-  python-pip \
-  python-dev \
-  wget \
-  npm \
-  ruby \
-  nodejs-legacy \
-  libpq-dev \
-  libnet-amazon-s3-tools-perl \
-  git \
-  build-essential \
-  libssl-dev \
-  libffi-dev
-# Application dependencies
-sudo apt-get install --fix-missing -y \
-  redis-server
-# Development tools
-sudo apt-get install --fix-missing -y \
-  htop
-# Test dependencies
-sudo apt-get install --fix-missing -y \
-  python-libxml2 \
-  python-libxslt1 \
-  python-dev
+cd /courtfinder_search
+sudo ./apt/production.sh
+sudo ./apt/development.sh
+sudo ./apt/testing.sh
 
 # Add the en_GB locale
+echo "Installing locale"
 locale -a | grep -q en_GB.utf8 || sudo locale-gen en_GB.UTF-8
 
 echo "Setting up virtualenv"
@@ -65,6 +43,7 @@ sudo chown vagrant /logs
 echo "Installing python dependencies"
 pip install setuptools==32
 pip install -r requirements.txt
+pip install -r requirements/testing.txt
 
 echo "Setting up postgres"
 sudo -u postgres bash -c "psql postgres -tAc 'SELECT 1 FROM pg_roles WHERE rolname='\''vagrant'\' | grep -q 1 || createuser --superuser vagrant"
@@ -77,6 +56,7 @@ cd /courtfinder_search/courtfinder/
 ./manage.py populate-db --datadir=../data/test_data --ingest
 
 echo "Installing frontend dependencies"
+sudo ln -s /usr/bin/nodejs /usr/bin/node
 sudo npm install gulp -g
 npm install
 sudo gem install sass


### PR DESCRIPTION
Add a Travis config file so that we can easily run tests against each new branch.

This change also extracts apt dependencies into separate scripts. The travis config was the third place that needs to install the same set of dependencies (Docker, vagrant bootstrapping, and now travis). I've pulled the dependencies out into three classes; basic build dependencies, development dependencies and test dependencies.

`npm` and `nodejs` are split out into a separate file and not installed on travis because travis already provides both and apt fails if we try to install them again. I have taken the opportunity to upgrade to the more recent `nodejs` package (`nodejs` rather than `nodejs-legacy`). This requires a symlink from the expected name of `node` to allow gulp to work.