### PR TITLE
RST-216 fix facilities text wrapping

### DIFF
--- a/courtfinder/assets-src/stylesheets/leaflet-print.scss
+++ b/courtfinder/assets-src/stylesheets/leaflet-print.scss
@@ -1,42 +1,45 @@
-@media print{
-	#global-breadcrumb, a[href='javascript:window.print()'], #feedback-banner, #global-header
-	{
+@media print {
+
+	#global-breadcrumb, a[href='javascript:window.print()'], #feedback-banner, #global-header {
 		display:none;
 	}
-	#leaflet
-  {
-    h2{
+
+	#leaflet {
+    h2 {
       color: black;
     }
+
     page-break-before: none;
     page-break-after: none;
   	page-break-inside: avoid;
-    
 	}
-	@page 
-    {
-        size:  auto;   /* auto is the initial value */
-        margin: 2.5em;
-        margin-bottom: 3em;
-        margin-top: 3em;
-    }
+
+	@page {
+    size:  auto;   /* auto is the initial value */
+    margin: 2.5em;
+    margin-bottom: 3em;
+    margin-top: 3em;
+  }
 
 	
 	@font-face {
-  		font-family: GDS-Logo;
-  		src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); 
-  	}
-  	#facilities {
+    font-family: GDS-Logo;
+    src: local("HelveticaNeue"), local("Helvetica Neue"), local("Arial"), local("Helvetica"); 
+  }
+
+  #facilities {
     li {
       clear: both;
     }
-    ul li .facility{
+
+    ul li .facility {
       width: 80% !important;
     }
+
     .icon {
       img {
         max-width: none !important;
       }
     }
-    }	  
+  }
 }	

--- a/courtfinder/assets-src/stylesheets/styles.scss
+++ b/courtfinder/assets-src/stylesheets/styles.scss
@@ -320,6 +320,11 @@ $small-width: 800px;
   #facilities {
     li {
       clear: both;
+
+      .facility {
+        display: block;
+        overflow: hidden;
+      }
     }
     .icon {
       position: relative;

--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -180,7 +180,7 @@
             <span class="icon">
               <img src="{% static facility.image_src %}" class="{{ facility.image_class }}" alt="{{ facility.image_description }}">
             </span>
-            <span class="facility">{{ facility.description|default:""|striptags }}</span>
+            <span class="facility">{{ facility.description|default:""|striptags|safe }}</span>
           </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
## RST-216 Fix facilities text wrapping
Hat-tip to Leo who provided the CSS.

## Tidy up the formatting of leaflets scss
I came across it because I was looking for styles relating to facilities.

## Mark facilities description as safe
This fixes a display issue where `&nbsp;` is getting displayed on the page. The facilities descriptions are safe because they are managed by staff and tags have already been stripped from the content.