### PR TITLE
Mapit usage tracking

### DIFF
--- a/courtfinder/courtfinder/settings/base.py
+++ b/courtfinder/courtfinder/settings/base.py
@@ -159,91 +159,36 @@ INSTALLED_APPS = INSTALLED_APPS + (
     'raven.contrib.django.raven_compat',
 )
 
-# Ensure logging directory is created
-LOGPATH = abspath(PROJECT_ROOT + '/../logs')
-if not os.path.exists(LOGPATH):
-    os.makedirs(LOGPATH)
-
 # Logging
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'root': {
+        'handlers': ['sentry'],
+        'level': 'DEBUG',
+    },
     'formatters': {
-        'simple': {
-            'format': '%(asctime)s %(message)s'
-        },
         'no-format': {
             'format': '%(message)s'
-        }
+        },
     },
     'handlers': {
-        'error-file': {
-            'level': 'ERROR',
-            'class': 'logging.FileHandler',
-            'formatter': 'simple',
-            'filename':  LOGPATH + '/errors.log',
-        },
-        'missed-las-file': {
-            'level': 'ERROR',
-            'class': 'logging.FileHandler',
-            'formatter': 'simple',
-            'filename': LOGPATH + '/missed-las.log',
-        },
-        'missed-aols-file': {
-            'level': 'ERROR',
-            'class': 'logging.FileHandler',
-            'formatter': 'simple',
-            'filename': LOGPATH + '/missed-aols.log',
-        },
-        'mapit-file': {
-            'level': 'ERROR',
-            'class': 'logging.FileHandler',
-            'formatter': 'simple',
-            'filename': LOGPATH + '/mapit.log',
-        },
-        'search-method-file': {
+        # TODO: Add support for JSON logs throughout the application
+        'courtfinder-requests': {
             'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'formatter': 'simple',
-            'filename': LOGPATH + '/search-method.log',
-        },
-        'courtfinder-requests-file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
+            'class': 'logging.StreamHandler',
             'formatter': 'no-format',
-            'filename': LOGPATH + '/requests.log',
-        }
+        },
+        'sentry': {
+            'level': 'ERROR',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
     },
     'loggers': {
-        'search.error': {
-            'handlers': ['error-file'],
-            'level': 'ERROR',
-            'propagate': True,
-        },
-        'search.mapit': {
-            'handlers': ['mapit-file'],
-            'level': 'ERROR',
-            'propagate': True,
-        },
-        'search.la': {
-            'handlers': ['missed-las-file'],
-            'level': 'ERROR',
-            'propagate': True,
-        },
-        'search.aol': {
-            'handlers': ['missed-aols-file'],
-            'level': 'ERROR',
-            'propagate': True,
-        },
-        'search.method': {
-            'handlers': ['search-method-file'],
-            'level': 'DEBUG',
-            'propagate': True,
-        },
         'courtfinder.requests': {
-            'handlers': ['courtfinder-requests-file'],
+            'handlers': ['courtfinder-requests'],
             'level': 'DEBUG',
-            'propagate': True,
+            'propagate': False,
         }
     },
 }

--- a/courtfinder/search/court_search.py
+++ b/courtfinder/search/court_search.py
@@ -250,8 +250,8 @@ class Postcode():
 
         if r.status_code == 200:
             try:
-                return json.loads(r.text)
-            except:
+                return r.json()
+            except ValueError:
                 raise CourtSearchError('MapIt: cannot parse response JSON')
         elif r.status_code in [400, 404]:
             loggers['mapit'].error("%d - %s - %s" % (r.status_code, postcode, r.text))

--- a/courtfinder/search/tests/test_postcode.py
+++ b/courtfinder/search/tests/test_postcode.py
@@ -8,16 +8,13 @@ from django.test import TestCase, Client
 from search.court_search import Postcode, CourtSearchInvalidPostcode, CourtSearchError
 
 
-class MockResponse():
-    def __init__(self):
-        self.status_code = 200
-        self.text = ''
-
-
 class PostcodeTestCase(TestCase):
-    mock_mapit_partial = '{"wgs84_lat": 51.47263752259685, "wgs84_lon": -0.06603088421009512, "postcode": "SE15" }'
-    mock_mapit_full = """
-        {
+    mock_mapit_partial = {
+        "wgs84_lat": 51.47263752259685,
+        "wgs84_lon": -0.06603088421009512,
+        "postcode": "SE15"
+    }
+    mock_mapit_full = {
             "postcode": "SE15 4UH",
             "shortcuts": { "WMC": 65913, "council": 2491, "ward": 8328 },
             "wgs84_lat": 51.468945906164286, "wgs84_lon": -0.06623508303668792,
@@ -31,14 +28,13 @@ class PostcodeTestCase(TestCase):
                     "generation_low": 1,
                     "id": 2491,
                     "name": "Southwark Borough Council",
-                    "parent_area": null,
+                    "parent_area": None,
                     "type": "LBO",
                     "type_name": "London borough"
                 }
             }
         }
-    """
-    mock_mapit_no_location = '{"postcode": "GY1 1AJ", "areas": {}}'
+    mock_mapit_no_location = {"postcode": "GY1 1AJ", "areas": {}}
 
     full_postcode = 'SE15 4UH'
     partial_postcode = 'SE15'
@@ -53,14 +49,15 @@ class PostcodeTestCase(TestCase):
         self.patcher.stop()
 
     def _get_from_mapit_mock( self, url, headers ):
-        mock_response = MockResponse()
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
 
         if url.endswith('SE15'):
-            mock_response.text =  PostcodeTestCase.mock_mapit_partial
+            mock_response.json.return_value =  PostcodeTestCase.mock_mapit_partial
         elif url.endswith('SE15 4UH'):
-            mock_response.text =  PostcodeTestCase.mock_mapit_full
+            mock_response.json.return_value =  PostcodeTestCase.mock_mapit_full
         elif url.endswith('GY1 1AJ'):
-            mock_response.text = PostcodeTestCase.mock_mapit_no_location
+            mock_response.json.return_value = PostcodeTestCase.mock_mapit_no_location
         elif url.endswith('Service Down'):
             mock_response.status_code = 500
         else:


### PR DESCRIPTION
MapIt returns the quota and current usage as response headers. This change logs both numbers and also the calculated percentage we are through the quota. Ultimately this will need to be in some monitoring system. Until we know what the best system is it can go here.

This PR also includes simplifying logging config and adding a Sentry handler.
I've simplified the logging config because when deployed the only logs that get shipped are those coming out on stdout and stderr so writing a bunch of different logs to different log files isn't much help.

