### PR TITLE
RST-223 Improve Mapit usage tracking

### DIFF
--- a/courtfinder/courtfinder/settings/base.py
+++ b/courtfinder/courtfinder/settings/base.py
@@ -162,22 +162,29 @@ INSTALLED_APPS = INSTALLED_APPS + (
 # Logging
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': False,
+    'disable_existing_loggers': True,
     'root': {
-        'handlers': ['sentry'],
+        'handlers': ['sentry', 'default'],
         'level': 'DEBUG',
     },
     'formatters': {
         'no-format': {
             'format': '%(message)s'
         },
+        'simple': {
+            'format': '%(asctime)s %(message)s'
+        },
     },
     'handlers': {
-        # TODO: Add support for JSON logs throughout the application
-        'courtfinder-requests': {
+        'json': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'no-format',
+        },
+        'default': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
         },
         'sentry': {
             'level': 'ERROR',
@@ -186,10 +193,15 @@ LOGGING = {
     },
     'loggers': {
         'courtfinder.requests': {
-            'handlers': ['courtfinder-requests'],
+            'handlers': ['json'],
             'level': 'DEBUG',
             'propagate': False,
-        }
+        },
+        'search.mapit.json': {
+            'handlers': ['json'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
     },
 }
 

--- a/courtfinder/search/tests/test_postcode.py
+++ b/courtfinder/search/tests/test_postcode.py
@@ -95,7 +95,7 @@ class PostcodeTestCase(TestCase):
 
     def test_log_usage(self):
         mapit_logger = mock.Mock()
-        with mock.patch.dict('search.court_search.loggers', mapit=mapit_logger):
+        with mock.patch.dict('search.court_search.loggers', mapit_json=mapit_logger):
             p = Postcode(self.partial_postcode)
 
             tests = [


### PR DESCRIPTION
The mapit usage tracking was not being logged and even if it was it
wasn't going to be very easy to use for a sensu alert. This commit
introduces a few changes to make that easier.

- Introduce a new deafult handler that logs to stdout
- Introduce a custom json handler
- Remove response text from mapit error logging, the response is long
  and multiline so messes up the logs for little value
- Make mapit usage logging json. This allows us to more easily add a
  sensu check.