### PR TITLE
Improve logging

### DIFF
--- a/courtfinder/core/middleware.py
+++ b/courtfinder/core/middleware.py
@@ -15,16 +15,17 @@ class RequestLoggingMiddleware(object):
     def process_response(self, request, response):
         try:
             self.logger.debug(json.dumps({
-                'responseCode': getattr(response, 'status_code', 0),
-                'responseTime': time() - self.request_time,
-                'time': strftime("%Y-%m-%d %H:%M:%S", gmtime()),
+                '@fields': {
+                    'status': getattr(response, 'status_code', 0),
+                    'request_time': time() - self.request_time,
+                    'remote_addr': request.META['REMOTE_ADDR'],
+                    'http_user_agent': request.META['HTTP_USER_AGENT'],
+                    'request_uri': request.get_full_path(),
+                },
                 'fullPath': request.get_full_path(),
                 'path': request.path,
-                'method': request.method,
                 'get': request.GET,
                 'post': request.POST,
-                'userAgent': request.META['HTTP_USER_AGENT'],
-                'ipAddress': request.META['REMOTE_ADDR'],
             }))
         except:
             pass

--- a/courtfinder/courtfinder/settings/test.py
+++ b/courtfinder/courtfinder/settings/test.py
@@ -6,6 +6,9 @@ from os import environ
 
 from .base import *
 
+import logging
+logging.disable(logging.CRITICAL)
+
 
 ########## DATABASE CONFIGURATION
 DATABASES = {

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -54,7 +54,6 @@ class SearchTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'search/aol.jinja')
         self.assertIn('About your issue', response.content)
-        print(response.content)
 
     def test_all_areas_of_law_have_descriptions(self):
         c = Client()


### PR DESCRIPTION
##  	Use ELK indexed field names for logs
If we use the field names indexed by ELK it allows us to do more complex searches and filters. It also allows us to more easily query across different sources.

##  	Disable logging in tests
Logging in tests clouds the output and makes it harder to read. This also removes a leftover print statement.