### PR TITLE
Fixed: Don't display map if lat or lon is null

### DIFF
--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -56,9 +56,11 @@
             <span property="addressRegion">{{ court.visiting_address.county }}</span><br/>
           {% endif %}
           <span property="postalCode">{{ court.visiting_address.postcode }}</span>
-          <p id="map-link">
-            <a href="https://maps.google.com/maps?q={{ court.lat }},{{ court.lon }}" target="_blank">Maps and directions <img src="{% static 'images/external-links/external-link-black-24x24.png' %}" alt="link opens an external website in a new window"/></a>
-          </p>
+          {% if court.lat and court.lon %}
+            <p id="map-link">
+              <a href="https://maps.google.com/maps?q={{ court.lat }},{{ court.lon }}" target="_blank">Maps and directions <img src="{% static 'images/external-links/external-link-black-24x24.png' %}" alt="link opens an external website in a new window"/></a>
+            </p>
+          {% endif %}
         </div>
       {% endif %}
       {% if court.postal_address %}
@@ -77,9 +79,11 @@
           {% endif %}
           {{ court.postal_address.postcode }}
           {% if court.postal_address.type.name == 'Postal and Visiting' %}
-            <p id="map-link">
-              <a href="https://maps.google.com/maps?q={{ court.lat }},{{ court.lon }}" target="_blank">Maps and directions <img src="{% static 'images/external-links/external-link-black-24x24.png' %}" alt="link opens an external website in a new window"/></a>
-          </p>
+            {% if court.lat and court.lon %}
+              <p id="map-link">
+                <a href="https://maps.google.com/maps?q={{ court.lat }},{{ court.lon }}" target="_blank">Maps and directions <img src="{% static 'images/external-links/external-link-black-24x24.png' %}" alt="link opens an external website in a new window"/></a>
+              </p>
+            {% endif %}
           {% endif %}
         </div>
       {% endif %}

--- a/courtfinder/courts/templates/courts/leaflets/juror/_travel.jinja
+++ b/courtfinder/courts/templates/courts/leaflets/juror/_travel.jinja
@@ -4,10 +4,12 @@
   <p>
        Lorem ipsum dolor sit amet, mei aliquip insolens referrentur an, mei atqui falli diceret ne, hinc persequeris eos id. Et utamur eloquentiam vix, summo soluta explicari usu ea. Ius eu dicat vivendum invenire, an simul soluta lobortis eos. Pro quaeque omnesque et, eu pri impetus mentitum persequeris, qui vidisse aperiri officiis et. Ex mei reque malis aeque, ne sed idque alterum.
   </p>
-   <p id="map-link">
-        <a target="_blank" href="https://maps.google.com/maps?q={{court.lat}},{{court.lon}}">
-          <img src="https://maps.googleapis.com/maps/api/staticmap?size=600x400&zoom=15&markers={{court.lat}},{{court.lon}}&key=AIzaSyC_b504UmVatMNUg1HCmbyuXoJ8meK6lpA" alt="map showing the location of {{ court.name }} (link opens external website in new window)"/>
-      </a>
-      <p><img src="http://maps.google.com/mapfiles/ms/icons/red-dot.png" alt='Google map marker'><span>- Location of {{court.name}}</span></s></p>
+  {% if court.lat and court.lon %}
+  <p id="map-link">
+    <a target="_blank" href="https://maps.google.com/maps?q={{court.lat}},{{court.lon}}">
+      <img src="https://maps.googleapis.com/maps/api/staticmap?size=600x400&zoom=15&markers={{court.lat}},{{court.lon}}&key=AIzaSyC_b504UmVatMNUg1HCmbyuXoJ8meK6lpA" alt="map showing the location of {{ court.name }} (link opens external website in new window)"/>
+    </a>
+    <p><img src="http://maps.google.com/mapfiles/ms/icons/red-dot.png" alt='Google map marker'><span>- Location of {{court.name}}</span></s></p>
   </p>
+  {% endif %}
 </div>


### PR DESCRIPTION
This fix prevents maps of Tuscany being offered to users of courts that have lost their latitude or longitude values and are not otherwise filtered. This is only a partial fix; the admin app should probably not allow a null  lat / long to be exported.