### PR TITLE
Add node.js in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 dist: trusty
+node_js:
+  - "0.10"
 python:
   - "2.7"
 notifications:


### PR DESCRIPTION
Travis is failing to install gulp because npm is missing. Installing Node.js will solve this issue.
It will be used the same nodejs version with production.