### PR TITLE
Use previous travis build version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+group: deprecated-2017Q2
 dist: trusty
 python:
   - "2.7"


### PR DESCRIPTION
https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch

This is a short term fix to allow work to continue on courtfinder-search
while we figure out how to fix it properly.