### PR TITLE
Add 'About jury service' link to Crown Court pages

### DIFF
--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -243,6 +243,9 @@
       <a href="https://hmctsformfinder.justice.gov.uk/HMCTS/FormFinder.do" title="Open the Formfinder tool to obtain the right form for your issue.">Find a form</a>
       <br/>
       <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/complaints-procedure" title="Information on providing feedback about our services and making a complaint.">Make a complaint</a>
+      {% if 'Crown Court' in court.types %}
+      <a href="https://www.gov.uk/jury-service">About jury service</a>
+      {% endif %}
     </div>
   {% if feature_leaflet_enabled %}
    <div id="leaflets">

--- a/courtfinder/courts/tests.py
+++ b/courtfinder/courts/tests.py
@@ -253,3 +253,12 @@ class SearchTestCase(TestCase):
             ],
             ["c", "b", "d"])
 
+    def test_jury_servive_link_not_shown_on_non_crown_court(self):
+        c = Client()
+        response = c.get('/courts/accrington-magistrates-court')
+        self.assertNotIn('About jury service', response.content)
+
+    def test_jury_service_link_shown_on_crown_court(self):
+        c = Client()
+        response = c.get('/courts/leaflet-crown-court')
+        self.assertIn('About jury service', response.content)


### PR DESCRIPTION
RST-361 As a juror I would like to access information on jury service, so that I can find out more about the task that I will be doing.