### PR TITLE
Pin npm dependency chalk to 1.1.3

### DIFF
--- a/docker/setup_npm.sh
+++ b/docker/setup_npm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-ln -s /usr/bin/nodejs /usr/bin/node
+[ -e /usr/bin/node ] || ln -s /usr/bin/nodejs /usr/bin/node
 npm install
 npm install gulp -g
 gem install sass

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/ministryofjustice/courtfinder-search"
   },
   "devDependencies": {
+    "chalk": "1.1.3",
     "govuk_frontend_toolkit": "^1.5.0",
     "gulp": "^3.8.11",
     "gulp-concat": "^2.3.4",


### PR DESCRIPTION
Chalk is being pulled in as an unrestricted dependency. It looks like
Chalk version 2.0.0 went to ES6 which now causes it to break on our
build. This change pins it to the most recent version before 2.0.0.

It also checks that /usr/bin/node doesn't exist before trying to symlink
it so that `setup_npm.sh` can be used more easily from vagrant.