### PR TITLE
Fix styling of RST-361

### DIFF
--- a/courtfinder/courts/templates/courts/court.jinja
+++ b/courtfinder/courts/templates/courts/court.jinja
@@ -244,6 +244,7 @@
       <br/>
       <a href="https://www.gov.uk/government/organisations/hm-courts-and-tribunals-service/about/complaints-procedure" title="Information on providing feedback about our services and making a complaint.">Make a complaint</a>
       {% if 'Crown Court' in court.types %}
+      <br/>
       <a href="https://www.gov.uk/jury-service">About jury service</a>
       {% endif %}
     </div>


### PR DESCRIPTION
Each link should be on a new line.

*before*
![before](https://user-images.githubusercontent.com/14287/27824705-3b01b998-60a5-11e7-8614-8aaefb995130.png)

*after*
![after](https://user-images.githubusercontent.com/14287/27824742-53f05c7a-60a5-11e7-99cd-af59060a5e46.png)

