### PR TITLE
RST-406 case insensitive area of law

### DIFF
--- a/courtfinder/search/court_search.py
+++ b/courtfinder/search/court_search.py
@@ -49,7 +49,7 @@ class CourtSearch:
             self.postcode = Postcode(postcode)
             try:
                 if area_of_law.lower() != 'all':
-                    self.area_of_law = AreaOfLaw.objects.get(name=area_of_law)
+                    self.area_of_law = AreaOfLaw.objects.get(name__iexact=area_of_law)
                 else:
                     self.area_of_law = AreaOfLaw(name=area_of_law)
             except AreaOfLaw.DoesNotExist:

--- a/courtfinder/search/tests/test_search.py
+++ b/courtfinder/search/tests/test_search.py
@@ -272,6 +272,10 @@ class SearchTestCase(TestCase):
         self.assertEqual(len(CourtSearch(postcode='SE15', area_of_law='Divorce')
                              .get_courts()), 1)
 
+    def test_area_of_law_case_insensitive(self):
+        self.assertEqual(len(CourtSearch(postcode='SE15', area_of_law='divorce')
+                             .get_courts()), 1)
+
     def test_local_authority_search_ordered(self):
         self.assertEqual(CourtSearch(postcode='SE154UH', area_of_law='Divorce')
                          .get_courts()[0].name, "Accrington Magistrates' Court")


### PR DESCRIPTION
It still isn't clear how the user managed to get to a URL with the area of law in lowecase but this change will mean that if it happens again the URL will work.