### PR TITLE
Run gulp through npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get clean \
 RUN mv ./docker/search /etc/sudoers.d/search
 
 RUN bash ./docker/setup_npm.sh
-RUN gulp
+RUN npm run gulp
 
 RUN pip install pip --upgrade
 RUN pip install -r requirements/production.txt

--- a/docker/setup_npm.sh
+++ b/docker/setup_npm.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e
 [ -e /usr/bin/node ] || ln -s /usr/bin/nodejs /usr/bin/node
 npm install
-npm install gulp -g
 gem install sass

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/ministryofjustice/courtfinder-search/issues"
   },
   "scripts": {
+    "gulp": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -57,8 +57,7 @@ python manage.py migrate --noinput
 
 echo "Installing frontend dependencies"
 sudo ln -s /usr/bin/nodejs /usr/bin/node
-sudo npm install gulp -g
 npm install
 sudo gem install sass
 
-gulp
+npm run gulp


### PR DESCRIPTION
This change moves away from installing gulp globally and instead runs gulp through npm. This means that the version of gulp is under the control of the package.json and not floating free.