### PR TITLE
Pin sass gem to 3.4.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - "pip install -r requirements/testing.txt"
   - "npm config set registry http://registry.npmjs.org/"
   - "npm install"
-  - "sudo gem install sass"
+  - "sudo gem install sass -v 3.4.21"
 before_script:
   - "psql -c 'CREATE DATABASE courtfinder_search;' -U postgres"
   - "python courtfinder/manage.py migrate --noinput"

--- a/docker/setup_npm.sh
+++ b/docker/setup_npm.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 [ -e /usr/bin/node ] || ln -s /usr/bin/nodejs /usr/bin/node
 npm install
-gem install sass
+gem install sass -v 3.4.21

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -58,6 +58,6 @@ python manage.py migrate --noinput
 echo "Installing frontend dependencies"
 sudo ln -s /usr/bin/nodejs /usr/bin/node
 npm install
-sudo gem install sass
+sudo gem install sass -v 3.4.21
 
 npm run gulp


### PR DESCRIPTION
http://sass-lang.com/documentation/file.SASS_CHANGELOG.html#3422_28_march_2016

sass 3.4.22 dropped support for Ruby 1.8 and 1.9.

Given that this is a Python project and we don't need any of the newer
features of sass it seems simplest to pin sass to the latest version
that supports the default Ruby version for ubuntu.