### PR TITLE
Rst 416 reduce size of docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+node_modules/
+data/postcodes/research/
+
+.sass-cache/
+courtfinder/assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
-FROM python:2.7
+FROM python:2.7-slim
 
 RUN useradd -m -d /srv/search search
 WORKDIR /srv/search
 
+# Install system dependencies and generate assets
 COPY apt/ ./apt
-RUN apt-get update && ./apt/production.sh
-
 COPY package.json gulpfile.js ./
 COPY docker/ ./docker
-RUN bash ./docker/setup_npm.sh && npm run gulp
+COPY courtfinder/assets-src/ ./courtfinder/assets-src
+RUN apt-get update && ./apt/production.sh \
+      && ./docker/setup_npm.sh && npm run gulp && rm -rf ./node_modules \
+      && apt-get purge -y --auto-remove ruby npm nodejs \
+      && rm -rf /var/lib/apt/lists/*
 
+# Install python dependencies
 COPY requirements/ ./requirements
 COPY requirements.txt ./requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Collect static assets
 ENV DJANGO_SETTINGS_MODULE courtfinder.settings.production
 RUN python courtfinder/manage.py collectstatic --noinput && \
     mkdir -p /srv/logs && chown -R search:search /srv/logs && \

--- a/apt/base.sh
+++ b/apt/base.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-apt-get install --fix-missing -y \
+apt-get install --fix-missing -y --no-install-recommends \
         postgis \
+        python-pip \
+        python-dev \
+        build-essential \
         wget \
         ruby \
         libpq-dev \


### PR DESCRIPTION
# Add .dockerignore
Reduce the size of the built image by ignoring files and directories from the build context.

# Switch to a slim base image
The standard python base image is almost 700MB. This change reduces the size of the built image by using the slim base image and adding just the dependencies we need.

There are a number of other changes to the Dockerfile to reduce the size of the image.
- Combine the `apt/production.sh` and asset building stages so that the asset building dependencies can be removed without ever getting commited to a layer.
- Remove the `node_modules`, asset building apt dependencies and apt lists
in the system dependencies / asset building stage.
- Do not use the cache when installing python dependencies.

Together these changes reduce the image size from 1.56GB to 784MB