### PR TITLE
Fix Dockerfile pre-1.9 versions of docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,8 +15,7 @@ RUN apt-get update && ./apt/production.sh \
 
 # Install python dependencies
 COPY requirements/ ./requirements
-COPY requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r ./requirements.txt
+RUN pip install --no-cache-dir -r ./requirements/local.txt
 
 # Collect static assets
 ENV DJANGO_SETTINGS_MODULE courtfinder.settings.production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,7 @@ services:
   courtfinder:
     build:
       context: .
-      dockerfile: Dockerfile
-      args:
-        PYTHON_REQUIREMENTS: ./requirements/local.txt
+      dockerfile: Dockerfile.dev
     environment:
       DJANGO_SETTINGS_MODULE: "courtfinder.settings.local"
       DB_HOST: "postgres"
@@ -46,9 +44,7 @@ services:
   test-unit:
     build:
       context: .
-      dockerfile: Dockerfile
-      args:
-        PYTHON_REQUIREMENTS: ./requirements/testing.txt
+      dockerfile: Dockerfile.dev
     environment:
       DJANGO_SETTINGS_MODULE: "courtfinder.settings.local"
       DB_HOST: "postgres"


### PR DESCRIPTION
The docker version on the build environment is pre-1.9 and therefore
does not understand the `ARG` command Dockerfiles. This change is not
ideal because it means changes to the Dockerfile now also need to be
applied to the Dockerfile.dev but upgrading the version of docker in the
build environment is a slightly bigger task and this is blocking
deploys.

https://docs.docker.com/release-notes/docker-engine/#190-2015-11-03