### PR TITLE
Rst 443 fix zap issues

### DIFF
--- a/courtfinder/courtfinder/settings/base.py
+++ b/courtfinder/courtfinder/settings/base.py
@@ -71,6 +71,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'core.middleware.RequestLoggingMiddleware',
 )
 
@@ -128,6 +129,9 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
+# Security middleware
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
 
 # Static files
 STATIC_URL = '/assets/'

--- a/courtfinder/courts/views.py
+++ b/courtfinder/courts/views.py
@@ -129,7 +129,7 @@ def court(request, slug):
 
 def leaflet(request, slug, leaflet_type):
     try:
-        format_court(Court.objects.get(slug=slug))
+        court = format_court(Court.objects.get(slug=slug))
     except Court.DoesNotExist:
         raise Http404
 

--- a/courtfinder/search/templates/search/postcode.jinja
+++ b/courtfinder/search/templates/search/postcode.jinja
@@ -8,9 +8,9 @@
   <ol role="breadcrumbs" class="group">
     <li><a href="{% url 'staticpages:home' %}">Home</a></li>
     <li><a href="{% url 'search:search' %}">Find a court or tribunal</a></li>
-    <li><a href="{% url 'search:aol' %}?aol={{aol}}">About your issue</a></li>
+    <li><a href="{% url 'search:aol' %}?aol={{aol|urlencode}}">About your issue</a></li>
     {% if spoe %}
-    <li><a href="{% url 'search:spoe' %}?aol={{aol}}&spoe={{spoe}}">Additional info</a></li>
+    <li><a href="{% url 'search:spoe' %}?aol={{aol|urlencode}}&spoe={{spoe|urlencode}}">Additional info</a></li>
     {% endif %}
   </ol>
 </div>

--- a/courtfinder/search/templates/search/results.jinja
+++ b/courtfinder/search/templates/search/results.jinja
@@ -15,11 +15,11 @@
         <li><a href="{% url 'search:address' %}">Search by name or address</a></li>
       {% endif %}
     {% else %}
-    <li><a href="{% url 'search:aol' %}?aol={{aol}}">About your issue</a></li>
+    <li><a href="{% url 'search:aol' %}?aol={{aol|urlencode}}">About your issue</a></li>
     {% if spoe %}
-    <li><a href="{% url 'search:spoe' %}?aol={{aol}}&spoe={{spoe}}">Additional info</a></li>
+    <li><a href="{% url 'search:spoe' %}?aol={{aol|urlencode}}&spoe={{spoe|urlencode}}">Additional info</a></li>
     {% endif %}
-    <li><a href="{% url 'search:postcode' %}?aol={{aol}}&spoe={{spoe}}&postcode={{postcode}}">Search by postcode</a></li>
+    <li><a href="{% url 'search:postcode' %}?aol={{aol|urlencode}}&spoe={{spoe|urlencode}}&postcode={{postcode|urlencode}}">Search by postcode</a></li>
     {% endif %}
   </ol>
 </div>

--- a/courtfinder/search/views.py
+++ b/courtfinder/search/views.py
@@ -200,12 +200,12 @@ def results_json(request):
         results = CourtSearch(postcode, aol, spoe, query).get_courts()
         return HttpResponse(json.dumps(__format_results(results), default=str),
                             content_type="application/json")
-    except CourtSearchError as e:
-        return HttpResponseServerError(
+    except (CourtSearchClientError, CourtSearchInvalidPostcode) as e:
+        return HttpResponseBadRequest(
                 '{"error":"%s"}' % e,
                 content_type="application/json")
-    except CourtSearchClientError as e:
-        return HttpResponseBadRequest(
+    except CourtSearchError as e:
+        return HttpResponseServerError(
                 '{"error":"%s"}' % e,
                 content_type="application/json")
 


### PR DESCRIPTION
## Fix 500 on leaflet pages
Looks like the pep8 commit 8f3b9a5 accidentally broke these pages.

## URL encode URL parameters
This addresses a reflected XSS alert marked as high risk.
See: https://cwe.mitre.org/data/definitions/79.html

## Return a 400 on invalid postcode
Previously it was returning a 500