### PR TITLE
RST-577 Reduce mapit 40x error logging

### DIFF
--- a/courtfinder/search/court_search.py
+++ b/courtfinder/search/court_search.py
@@ -258,7 +258,7 @@ class Postcode():
             except ValueError:
                 raise CourtSearchError('MapIt: cannot parse response JSON')
         elif r.status_code in [400, 404]:
-            loggers['mapit'].error("%d - %s" % (r.status_code, postcode))
+            loggers['mapit'].info("%d - %s" % (r.status_code, postcode))
             raise CourtSearchInvalidPostcode('MapIt doesn\'t know this postcode: ' + mapit_url)
         elif r.status_code in [403, 429]:
             loggers['mapit'].error("%d - %s" % (r.status_code, postcode))


### PR DESCRIPTION
Bad user input and unrecognised postcodes should not be logged in sentry
as errors, filling up the log